### PR TITLE
Use dt.parse_datetime for agreement dates

### DIFF
--- a/custom_components/octopus_energy/utils.py
+++ b/custom_components/octopus_energy/utils.py
@@ -1,16 +1,13 @@
-from datetime import datetime
-from homeassistant.util.dt import (utcnow, as_utc)
+from homeassistant.util.dt import (utcnow, as_utc, parse_datetime)
 
 def get_active_agreement(agreements):
-  active_agreement = None
   now = utcnow()
 
   for agreement in agreements:
-    valid_from = as_utc(datetime.fromisoformat(agreement["valid_from"]))
-    valid_to = as_utc(datetime.fromisoformat(agreement["valid_to"]))
+    valid_from = as_utc(parse_datetime(agreement["valid_from"]))
+    valid_to = as_utc(parse_datetime(agreement["valid_to"]))
 
     if valid_from <= now and valid_to >= now:
-      active_agreement = agreement
-      break
+      return agreement
   
-  return active_agreement
+  return None


### PR DESCRIPTION
I was getting an error when the agreement date was being parsed: `ValueError: Invalid isoformat string: '2020-01-22T00:00:00Z'`

It appears that `datetime.fromisoformat` is [not designed to parse arbitrary ISO-8601 formatted dates](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat). Home Assistant provides `util.dt.parse_datetime`, which seems to support timezones.