### PR TITLE
feat: Updated to support duel rate tariffs (e.g. day/night).

### DIFF
--- a/custom_components/octopus_energy/api_client.py
+++ b/custom_components/octopus_energy/api_client.py
@@ -1,7 +1,7 @@
 import logging
 import aiohttp
 from datetime import (timedelta)
-from homeassistant.util.dt import (utcnow, as_utc, parse_datetime)
+from homeassistant.util.dt import (utcnow, as_utc, now, as_local, parse_datetime)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +29,8 @@ class OctopusEnergyApiClient:
         
         return None
 
-  def process_rates(self, data, period_from, period_to):
+  def __process_rates(self, data, period_from, period_to):
+    """Process the collection of rates to ensure they're in 30 minute periods"""
     starting_period_from = period_from
     results = []
     if ("results" in data):
@@ -41,13 +42,13 @@ class OctopusEnergyApiClient:
 
         if "valid_from" in item and item["valid_from"] != None:
           valid_from = as_utc(parse_datetime(item["valid_from"]))
-        else:
-          target_date = starting_period_from
 
-        # If we're on a fixed rate, then our current time could be in the past so we should go from
-        # our target period from date otherwise we could be adjusting times quite far in the past
-        if valid_from < period_from:
-          valid_from = period_from
+          # If we're on a fixed rate, then our current time could be in the past so we should go from
+          # our target period from date otherwise we could be adjusting times quite far in the past
+          if (valid_from < starting_period_from):
+            valid_from = starting_period_from
+        else:
+          valid_from = starting_period_from
 
         # Some rates don't have end dates, so we should treat this as our period to target
         if "valid_to" in item and item["valid_to"] != None:
@@ -69,27 +70,91 @@ class OctopusEnergyApiClient:
       
     return results
 
-  async def async_get_rates(self, product_code, tariff_code):
-    """Get the current rates"""
+  async def async_get_standard_rates_for_next_two_days(self, product_code, tariff_code):
+    """Get the current standard rates"""
+    results = []
     async with aiohttp.ClientSession() as client:
       auth = aiohttp.BasicAuth(self._api_key, '')
-      now = utcnow()
-      period_from = as_utc(parse_datetime(now.strftime("%Y-%m-%dT00:00:00Z")))
-      period_to = as_utc(parse_datetime((now + timedelta(days=2)).strftime("%Y-%m-%dT00:00:00Z")))
+      utc_now = utcnow()
+      period_from = as_utc(parse_datetime(utc_now.strftime("%Y-%m-%dT00:00:00Z")))
+      period_to = as_utc(parse_datetime((utc_now + timedelta(days=2)).strftime("%Y-%m-%dT00:00:00Z")))
       url = f'{self._base_url}/v1/products/{product_code}/electricity-tariffs/{tariff_code}/standard-unit-rates?period_from={period_from.strftime("%Y-%m-%dT%H:%M:%SZ")}&period_to={period_to.strftime("%Y-%m-%dT%H:%M:%SZ")}'
       async with client.get(url, auth=auth) as response:
-        # Disable content type check as sometimes it can report text/html
-        results = []
         try:
+          # Disable content type check as sometimes it can report text/html
           data = await response.json(content_type=None)
-          results = self.process_rates(data, period_from, period_to)
+          results = self.__process_rates(data, period_from, period_to)
         except:
-          _LOGGER.error(f'Failed to extract rates: {url}')
+          _LOGGER.error(f'Failed to extract standard rates: {url}')
           raise
 
-        return results
+    return results
 
-  def process_consumption(self, item):
+  def __get_valid_from(self, rate):
+    return rate["valid_from"]
+
+  def __is_between_local_times(self, rate, target_from_time, target_to_time):
+    """Determines if a current rate is between two times"""
+    local_now = now()
+
+    rate_local_valid_from = as_local(rate["valid_from"])
+    rate_local_valid_to = as_local(rate["valid_to"])
+
+    # We need to convert our times into local time to account for BST to ensure that our rate is valid between the target times.
+    from_date_time = as_local(parse_datetime(rate_local_valid_from.strftime(f"%Y-%m-%dT{target_from_time}{local_now.strftime('%z')}")))
+    to_date_time = as_local(parse_datetime(rate_local_valid_from.strftime(f"%Y-%m-%dT{target_to_time}{local_now.strftime('%z')}")))
+
+    _LOGGER.error('is_valid: %s; from_date_time: %s; to_date_time: %s; rate_local_valid_from: %s; rate_local_valid_to: %s', rate_local_valid_from >= from_date_time and rate_local_valid_from < to_date_time, from_date_time, to_date_time, rate_local_valid_from, rate_local_valid_to)
+
+    return rate_local_valid_from >= from_date_time and rate_local_valid_from < to_date_time
+
+  async def async_get_day_night_rates_for_next_two_days(self, product_code, tariff_code):
+    """Get the current day and night rates"""
+    results = []
+    async with aiohttp.ClientSession() as client:
+      auth = aiohttp.BasicAuth(self._api_key, '')
+      utc_now = utcnow()
+      period_from = as_utc(parse_datetime(utc_now.strftime("%Y-%m-%dT00:00:00Z")))
+      period_to = as_utc(parse_datetime((utc_now + timedelta(days=2)).strftime("%Y-%m-%dT00:00:00Z")))
+      url = f'{self._base_url}/v1/products/{product_code}/electricity-tariffs/{tariff_code}/day-unit-rates?period_from={period_from.strftime("%Y-%m-%dT%H:%M:%SZ")}&period_to={period_to.strftime("%Y-%m-%dT%H:%M:%SZ")}'
+      async with client.get(url, auth=auth) as response:
+        try:
+          # Disable content type check as sometimes it can report text/html
+          data = await response.json(content_type=None)
+
+          # Normalise the rates to be in 30 minute increments and remove any rates that fall outside of our day period 
+          # (7am to 12am UK time https://octopus.energy/help-and-faqs/categories/tariffs/eco-seven/)
+          day_rates = self.__process_rates(data, period_from, period_to)
+          for rate in day_rates:
+            if (self.__is_between_local_times(rate, "07:00:00", "23:59:59")) == True:
+              results.append(rate)
+        except:
+          _LOGGER.error(f'Failed to extract day rates: {url}')
+          raise
+
+      url = f'{self._base_url}/v1/products/{product_code}/electricity-tariffs/{tariff_code}/night-unit-rates?period_from={period_from.strftime("%Y-%m-%dT%H:%M:%SZ")}&period_to={period_to.strftime("%Y-%m-%dT%H:%M:%SZ")}'
+      async with client.get(url, auth=auth) as response:
+        try:
+          # Disable content type check as sometimes it can report text/html
+          data = await response.json(content_type=None)
+
+          # Normalise the rates to be in 30 minute increments and remove any rates that fall outside of our night period 
+          # (12am to 7am UK time https://octopus.energy/help-and-faqs/categories/tariffs/eco-seven/)
+          night_rates = self.__process_rates(data, period_from, period_to)
+          for rate in night_rates:
+            if (self.__is_between_local_times(rate, "00:00:00", "07:00:00")) == True:
+              results.append(rate)
+        except:
+          _LOGGER.error(f'Failed to extract night rates: {url}')
+          raise
+
+    # Because we retrieve our day and night periods separately over a 2 day period, we need to sort our rates 
+    results.sort(key=self.__get_valid_from)
+    _LOGGER.error(results)
+
+    return results
+
+  def __process_consumption(self, item):
     return {
       "consumption": float(item["consumption"]),
       "interval_start": as_utc(parse_datetime(item["interval_start"])),
@@ -108,7 +173,7 @@ class OctopusEnergyApiClient:
           data = data["results"]
           results = []
           for item in data:
-            item = self.process_consumption(item)
+            item = self.__process_consumption(item)
 
             # For some reason, the end point returns slightly more data than we requested, so we need to filter out
             # the results
@@ -131,7 +196,7 @@ class OctopusEnergyApiClient:
           data = data["results"]
           results = []
           for item in data:
-            item = self.process_consumption(item)
+            item = self.__process_consumption(item)
 
             # For some reason, the end point returns slightly more data than we requested, so we need to filter out
             # the results

--- a/custom_components/octopus_energy/const.py
+++ b/custom_components/octopus_energy/const.py
@@ -20,7 +20,7 @@ DATA_RATES = "RATES"
 REGEX_HOURS = "^[0-9]+(\.[0-9]+)*$"
 REGEX_TIME = "^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$"
 REGEX_ENTITY_NAME = "^[a-z0-9_]+$"
-REGEX_PRODUCT_NAME = "^[A-Z]-[0-9A-Z]+-([A-Z0-9-]+)-[A-Z]$"
+REGEX_TARIFF_PARTS = "^[A-Z]-([0-9A-Z]+)-([A-Z0-9-]+)-[A-Z]$"
 
 DATA_SCHEMA_ACCOUNT = vol.Schema({
   vol.Required(CONFIG_MAIN_API_KEY): str,


### PR DESCRIPTION
Updated the api client to include option for retrieving day/night tariffs, where results are normalised into 30 minute increments.
Updated update_data to use correct rate endpoint depending on tariff

Relates to https://github.com/BottlecapDave/HomeAssistant-OctopusEnergy/issues/11