### PR TITLE
Added full rate details as attributes for electricity meters

### DIFF
--- a/custom_components/octopus_energy/sensor.py
+++ b/custom_components/octopus_energy/sensor.py
@@ -223,9 +223,15 @@ class OctopusEnergyElectricityCurrentRate(CoordinatorEntity, SensorEntity):
               break
 
       if current_rate != None:
+        ratesAttributes = list(map(lambda x: {
+          "from": x["valid_from"],
+          "to":   x["valid_to"],
+          "rate": x["value_inc_vat"]
+        }, rate))
         self._attributes = {
           "rate": current_rate,
-          "is_export": self._is_export
+          "is_export": self._is_export,
+          "rates": ratesAttributes
         }
         
         self._state = current_rate["value_inc_vat"] / 100


### PR DESCRIPTION
The full rate data can be useful in some advanced use cases where a target
rate can't be used. One such example is combining electricity export rate
data with a solar PV forecast to determine when is the best time to charge a
battery.