### PR TITLE
Fixed day/night times for economy 7 tariffs when using a smart meter.

### DIFF
--- a/custom_components/octopus_energy/sensor_utils.py
+++ b/custom_components/octopus_energy/sensor_utils.py
@@ -64,14 +64,14 @@ def calculate_electricity_consumption(consumption_data, last_calculated_timestam
         "consumptions": consumption_parts
       }
 
-async def async_calculate_electricity_cost(client: OctopusEnergyApiClient, consumption_data, last_calculated_timestamp, period_from, period_to, tariff_code):
+async def async_calculate_electricity_cost(client: OctopusEnergyApiClient, consumption_data, last_calculated_timestamp, period_from, period_to, tariff_code, is_smart_meter):
   if (consumption_data != None and len(consumption_data) > 0):
 
     sorted_consumption_data = __sort_consumption(consumption_data)
 
     # Only calculate our consumption if our data has changed
     if (last_calculated_timestamp == None or last_calculated_timestamp < sorted_consumption_data[-1]["interval_end"]):
-      rates = await client.async_get_electricity_rates(tariff_code, period_from, period_to)
+      rates = await client.async_get_electricity_rates(tariff_code, is_smart_meter, period_from, period_to)
       standard_charge_result = await client.async_get_electricity_standing_charge(tariff_code, period_from, period_to)
 
       if (rates != None and len(rates) > 0 and standard_charge_result != None):

--- a/tests/integration/api_client/test_get_account.py
+++ b/tests/integration/api_client/test_get_account.py
@@ -27,6 +27,7 @@ async def test_when_get_account_is_called_then_electricity_and_gas_points_return
     assert len(meter_point["meters"]) == 1
     meter = meter_point["meters"][0]
     assert meter["is_export"] == False
+    assert meter["is_smart_meter"] == True
     assert meter["serial_number"] == context["electricity_serial_number"]
 
     assert "agreements" in meter_point

--- a/tests/integration/api_client/test_get_electricity_rates.py
+++ b/tests/integration/api_client/test_get_electricity_rates.py
@@ -5,7 +5,7 @@ import pytest
 from integration import get_test_context
 from custom_components.octopus_energy.api_client import OctopusEnergyApiClient
 
-async def async_assert_electricity_data(tariff):
+async def async_assert_electricity_data(tariff, is_smart_meter):
     # Arrange
     context = get_test_context()
 
@@ -14,7 +14,7 @@ async def async_assert_electricity_data(tariff):
     period_to = datetime.strptime("2021-12-03T00:00:00Z", "%Y-%m-%dT%H:%M:%S%z")
 
     # Act
-    data = await client.async_get_electricity_rates(tariff, period_from, period_to)
+    data = await client.async_get_electricity_rates(tariff, is_smart_meter, period_from, period_to)
 
     # Assert
     assert len(data) == 96
@@ -34,24 +34,29 @@ async def async_assert_electricity_data(tariff):
 @pytest.mark.asyncio
 async def test_when_get_electricity_rates_is_called_with_fixed_tariff_then_data_is_returned_in_thirty_minute_increments():
     tariff = "E-1R-SUPER-GREEN-24M-21-07-30-A"
-    await async_assert_electricity_data(tariff)
+    await async_assert_electricity_data(tariff, False)
 
 @pytest.mark.asyncio
 async def test_when_get_electricity_rates_is_called_with_go_tariff_then_data_is_returned_in_thirty_minute_increments():
     tariff = "E-1R-GO-18-06-12-A"
-    await async_assert_electricity_data(tariff)
+    await async_assert_electricity_data(tariff, False)
 
 @pytest.mark.asyncio
 async def test_when_get_electricity_rates_is_called_with_variable_tariff_then_data_is_returned_in_thirty_minute_increments():
     tariff = "E-1R-VAR-21-09-29-A"
-    await async_assert_electricity_data(tariff)
+    await async_assert_electricity_data(tariff, False)
 
 @pytest.mark.asyncio
 async def test_when_get_electricity_rates_is_called_with_agile_tariff_then_data_is_returned_in_thirty_minute_increments():
     tariff = "E-1R-AGILE-18-02-21-A"
-    await async_assert_electricity_data(tariff)
+    await async_assert_electricity_data(tariff, False)
 
 @pytest.mark.asyncio
-async def test_when_get_electricity_rates_is_called_with_duel_rate_tariff_then_data_is_returned_in_thirty_minute_increments():
+async def test_when_get_electricity_rates_is_called_with_duel_rate_tariff_dumb_meter_then_data_is_returned_in_thirty_minute_increments():
     tariff = "E-2R-SUPER-GREEN-24M-21-07-30-A"
-    await async_assert_electricity_data(tariff)
+    await async_assert_electricity_data(tariff, False)
+
+@pytest.mark.asyncio
+async def test_when_get_electricity_rates_is_called_with_duel_rate_tariff_smart_meter_then_data_is_returned_in_thirty_minute_increments():
+    tariff = "E-2R-SUPER-GREEN-24M-21-07-30-A"
+    await async_assert_electricity_data(tariff, True)

--- a/tests/integration/test_calculate_electricity_cost.py
+++ b/tests/integration/test_calculate_electricity_cost.py
@@ -34,7 +34,7 @@ async def test_when_calculate_electricity_cost_uses_real_data_then_calculation_r
   )
 
   # Make sure we have rates and standing charges available
-  rates = await client.async_get_electricity_rates(tariff_code, period_from, period_to)
+  rates = await client.async_get_electricity_rates(tariff_code, False, period_from, period_to)
   assert rates != None
   assert len(rates) > 0
 
@@ -48,7 +48,8 @@ async def test_when_calculate_electricity_cost_uses_real_data_then_calculation_r
     latest_date,
     period_from,
     period_to,
-    tariff_code
+    tariff_code,
+    False
   )
 
   # Assert

--- a/tests/unit/test_calculate_electricity_cost.py
+++ b/tests/unit/test_calculate_electricity_cost.py
@@ -22,7 +22,8 @@ async def test_when_electricity_consumption_is_none_then_no_calculation_is_retur
     latest_date,
     period_from,
     period_to,
-    tariff_code
+    tariff_code,
+    False
   )
 
   # Assert
@@ -44,7 +45,8 @@ async def test_when_electricity_consumption_is_empty_then_no_calculation_is_retu
     latest_date,
     period_from,
     period_to,
-    tariff_code
+    tariff_code,
+    False
   )
 
   # Assert
@@ -70,7 +72,8 @@ async def test_when_electricity_consumption_is_before_latest_date_then_no_calcul
     latest_date,
     period_from,
     period_to,
-    tariff_code
+    tariff_code,
+    False
   )
 
   # Assert
@@ -115,7 +118,8 @@ async def test_when_electricity_consumption_available_then_calculation_returned(
       latest_date,
       period_from,
       period_to,
-      tariff_code
+      tariff_code,
+      False
     )
 
     # Assert
@@ -186,7 +190,8 @@ async def test_when_electricity_consumption_starting_at_latest_date_then_calcula
       latest_date,
       period_from,
       period_to,
-      tariff_code
+      tariff_code,
+      False
     )
 
     # Assert


### PR DESCRIPTION
According to the the page below the off peak night rate is at a different
time if you have a smart meter. This patch adds a config option to select
if a smart meter is installed, and uses that to calculate the correct
time to change to the night rate.
https://octopus.energy/help-and-faqs/articles/what-happens-to-my-economy-seven-e7-tariff-when-i-have-a-smart-meter-installed/