### PR TITLE
Document where to set override tariff

### DIFF
--- a/_docs/sensors/electricity.md
+++ b/_docs/sensors/electricity.md
@@ -305,6 +305,13 @@ Instructions on how to find tariffs can be found in the [faq](../faq.md#i-want-t
 
 > Please note: When updating the tariff depending on what previous consumption data is available, it can take up to 24 hours to update the cost. This will be improved in the future.
 
+Once enabled, you can set the tariff you wish to use for the override in the device controls
+
+1. Navigate to [your devices](https://my.home-assistant.io/redirect/devices/)
+2. Search for "Octopus Energy"
+3. Click on one of the meters
+4. Enter the tariff code in the Controls field for the override sensor.
+
 ### Previous Accumulative Cost Override Tariff (Electricity)
 
 `text.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_cost_override_tariff`

--- a/_docs/sensors/gas.md
+++ b/_docs/sensors/gas.md
@@ -182,11 +182,18 @@ The total cost for the current day, including the standing charge.
 
 ## Tariff Overrides
 
-You may be on an existing tariff but want to know if the grass is greener (or cheaper) on the other side. The following entities are available in a disabled state, which when enabled can give you an indication what you'd be paying if you were on a different tariff and didn't change your energy habits. 
+You may be on an existing tariff but want to know if the grass is greener (or cheaper) on the other side. The following entities are available in a disabled state, which when enabled can give you an indication what you'd be paying if you were on a different tariff and didn't change your energy habits.
 
 Instructions on how to find tariffs can be found in the [faq](../faq.md#i-want-to-use-the-tariff-overrides-but-how-do-i-find-an-available-tariff).
 
 > Please note: When updating the tariff depending on what previous consumption data is available, it can take up to 24 hours to update the cost. This will be improved in the future.
+
+Once enabled, you can set the tariff you wish to use for the override in the device controls
+
+1. Navigate to [your devices](https://my.home-assistant.io/redirect/devices/)
+2. Search for "Octopus Energy"
+3. Click on one of the meters
+4. Enter the tariff code in the Controls field for the override sensor.
 
 ### Previous Accumulative Cost Override Tariff (Gas)
 


### PR DESCRIPTION
This PR adds an explanation to the electicity and gas overrides section detailing where the user needs to set the override tariff as it isn't obvious.

I spent waaaay to long investigating this and only worked it out after looking at the source code. This is way too much effort for a standard user so I'm adding a little section to the docs to make it clearer.

I've taken the basic steps from the "I've been asked for my meter information in a bug request, how do I obtain this?" in the FAQ to keep things consistent.

I'm not wed to the wording so feel free to tweak directly.