### PR TITLE
Update energy_dashboard.md expanded electricity monitoring instructions

### DIFF
--- a/_docs/energy_dashboard.md
+++ b/_docs/energy_dashboard.md
@@ -12,16 +12,54 @@
 
 ### For Electricity
 
-<img src="./assets/current_consumption_electricity.png" alt="HA modal electricity example" height="500">
+You can only record current (i.e. today's) consumption in the Energy dashboard if you have a way of measuring live consumption in your home.
 
-This is only available if you have an Octopus Home Mini and a smart electricity meter.
+There are 4 possible ways to obtain this data:
+
+#### 1. Octopus Home Mini
+
+If you have an Octopus Home Mini and a smart electricity meter you can obtain live meter reading data into Home Assistant:
 
 1. Go to your [energy dashboard configuration](https://my.home-assistant.io/redirect/config_energy/)
 2. Click `Add Consumption` under `Electricity Grid`
 3. For `consumed energy` you want `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_current_consumption` or `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_current_accumulative_consumption`
 4. For `Use an entity tracking the total costs` option you want `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_current_accumulative_cost`
 
+<img src="./assets/current_consumption_electricity.png" alt="HA modal electricity example" height="500">
+
 > Please note that data will only appear in the energy dashboard from the point you configure the Home Mini within the integration. It doesn't backport any data.
+
+#### 2. Hildebrand Glow In Home Display
+
+If you have a [Hildebrand Glow In Home Display](https://shop.glowmarkt.com/) and a smart meter you can retrieve live meter reading information in Home Assistant via local MQTT access - see this [Speak to the Geek article](https://www.speaktothegeek.co.uk/2022/06/hildebrand-glow-update-local-mqtt-and-home-assistant/) for setup instructions.
+
+Setup in the Energy dashboard is very similar to that for the Octopus Home Mini, except that:
+
+3. For `consumed energy` you want the name of the sensor you created to store the Hildebrand MQTT reading in, e.g. `sensor.smart_meter_electricity_energy_import`
+
+#### 3. Hildebrand Glow DCC Integration
+
+If you don't have a Hildebrand Glow IHD but do have a smart meter, you can still retrieve your daily consumption information from the central DCC smart meter database using the Hildebrand Glow API and the [Hildebrand Glow DCC Home Assistant integration](https://github.com/HandyHat/ha-hildebrandglow-dcc).  The data in the central DCC database is said to be delayed by 30 minutes but in practice has been seen to quite "lumpy" with big jumps in consumption throughout the day as meter reading updates feed through periodically into the central database.  Only a single daily consumption figure is provided so unless you are on a single daily flat rate consumption tariff this integration is not likely to be suitable for calculating daily costs.
+
+3. The daily consumption is provided by `sensor.dcc_sourced_smart_electricity_meter_usage_today`
+
+#### 4. Use an Energy Clamp or Inverter to measure Home Consumption
+
+If you use an Energy CT Clamp such as the Shelly EM on the incoming supply cable you can feed live import and export energy information into Home Assistant. Or if you have an existing Solar/Battery inverter integrated into Home Assistant the inverter could well also have a sensor that provides Grid import information that you can use in the Energy dashboard.
+
+Either of these approaches will also work regardless of whether you have a smart meter or not.
+
+Do be aware that as you are not directly capturing the smart meter readings in Home Assistant there will always be a small measurement difference from what Octopus energy say you have used, but in practice the difference is likely to be quite small.
+
+1. Create a utility meter to store the sensor information in.  Go to [Integrations dashboard](https://my.home-assistant.io/redirect/integrations/)
+2. Click `Helpers` tab
+3. Click `Create Helper` at the bottom right-hand corner
+4. Choose `Utility Meter`
+5. Enter a name for it, e.g. `Grid Import Today`
+6. Choose the name of the sensor that is measuring your grid import. e.g. for a Shelly EM it will be `sensor.<EM channel name>_energy_total`; for a GivEnergy inverter using the GivTCP integration it will be `sensor.givtcp_XXyywwXnnn_import_energy_today_kwh`
+7. For `Meter reset cycle` chose `Daily`
+8. Click `Submit`
+9. Then add the consumption information to the Energy dashboard as per the steps for Octopus Home Mini above.  For step 3, `consumed energy`, you want the utility meter you have just created above, e.g. `sensor.grid_import_today`
 
 ### For Gas
 
@@ -38,9 +76,11 @@ This is only available if you have an Octopus Home Mini and a smart gas meter.
 
 ## Previous Day Consumption
 
-While you can add the `previous consumption` sensors to the dashboard, they will be associated with the wrong day. This is because the Energy dashboard uses the timestamp of when the sensor updates to determine which day the data should belong to.
+If none of the methods above for feeding Current Day Consumption information into the Energy dashboard are suitable, you can add `previous consumption` sensors to the dashboard, using information retrieved via the Octopus API.  Note that the consumption information is only available on the following day so "today's" Energy dashboard will show zero values, but "yesterday's", "day before", etc will show the correct consumption for each day.
 
-Instead, you can use external statistics that are exported by the `previous consumption` sensors, which are broken down into hourly chunks. Please note it can take **up to 24 hours** for the external statistics to appear.
+Beware: Whilst you can add the previous consumption sensors directly to the Energy dashboard, they will be associated with the wrong day. This is because the Energy dashboard uses the timestamp of when the sensor updates to determine which day the data should belong to.
+
+Instead, you **must** use external statistics that are exported by the `previous consumption` sensors, which are broken down into hourly chunks. Please note it can take **up to 24 hours** for the external statistics to appear.
 
 > Please note: I'm still investigating having hourly breakdowns imported on the entity themselves rather than as external statistics, but currently in doing so it's still including the spikes on the day of retrieval. I've opened a [forum post](https://community.home-assistant.io/t/help-needed-around-importing-historic-statistics/567726) but awaiting answers.
 
@@ -50,11 +90,11 @@ Instead, you can use external statistics that are exported by the `previous cons
 
 1. Go to your [energy dashboard configuration](https://my.home-assistant.io/redirect/config_energy/)
 2. Click `Add Consumption` under `Electricity Grid`
-3. For `consumed energy` you want one of the following
-* `octopus_energy:electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_consumption` - The total consumption reported by the meter for the previous day. **Please note the different name to the standard entity.**
-* `octopus_energy:electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_consumption_peak` - The total consumption reported by the meter for the previous day that applied during peak hours. This is [disabled by default](./faq.md#there-are-entities-that-are-disabled-why-are-they-disabled-and-how-do-i-enable-them). This will only be populated if you're on a tariff with two available rates.  **Please note the different name to the standard entity.**
-* `octopus_energy:electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_consumption_off_peak` - The total consumption reported by the meter for the previous day that applied during off peak hours. This is [disabled by default](./faq.md#there-are-entities-that-are-disabled-why-are-they-disabled-and-how-do-i-enable-them). This will only be populated if you're on a tariff with two available rates.  **Please note the different name to the standard entity.**
-1. For `Use an entity tracking the total costs` option you want one of the following
+3. For `consumed energy` you want one of the following:
+ * **`octopus_energy:`**`electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_consumption` - The total consumption reported by the meter for the previous day.  **Please note the different name to the standard entity, do NOT choose sensor.electricity_{{METER}}_{{MPAN}}_previous_accumulative_consumption.**
+ * **`octopus_energy:`**`electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_consumption_peak` - The total consumption reported by the meter for the previous day that applied during peak hours. This is [disabled by default](./faq.md#there-are-entities-that-are-disabled-why-are-they-disabled-and-how-do-i-enable-them). This will only be populated if you're on a tariff with two available rates.  **Please note the different name to the standard entity.**
+ * **`octopus_energy:`**`electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_consumption_off_peak` - The total consumption reported by the meter for the previous day that applied during off peak hours. This is [disabled by default](./faq.md#there-are-entities-that-are-disabled-why-are-they-disabled-and-how-do-i-enable-them). This will only be populated if you're on a tariff with two available rates.  **Please note the different name to the standard entity.**
+4. For `Use an entity tracking the total costs` option you want one of the following:
 * `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_cost` - The total cost for the previous day.
 * `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_cost_peak` - The total cost for the previous day that applied during peak hours. This is [disabled by default](./faq.md#there-are-entities-that-are-disabled-why-are-they-disabled-and-how-do-i-enable-them). This will only be populated if you're on a tariff with two available rates.
 * `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_cost_off_peak` - The total cost for the previous day that applied during off peak hours. This is [disabled by default](./faq.md#there-are-entities-that-are-disabled-why-are-they-disabled-and-how-do-i-enable-them). This will only be populated if you're on a tariff with two available rates.

--- a/_docs/energy_dashboard.md
+++ b/_docs/energy_dashboard.md
@@ -14,9 +14,7 @@
 
 You can only record current (i.e. today's) consumption in the Energy dashboard if you have a way of measuring live consumption in your home.
 
-There are 4 possible ways to obtain this consumption data:
-
-#### 1. Octopus Home Mini
+#### Octopus Home Mini
 
 If you have an Octopus Home Mini and a smart electricity meter you can obtain live meter reading data into Home Assistant:
 
@@ -29,37 +27,15 @@ If you have an Octopus Home Mini and a smart electricity meter you can obtain li
 
 > Please note that data will only appear in the energy dashboard from the point you configure the Home Mini within the integration. It doesn't backport any data.
 
-#### 2. Hildebrand Glow In Home Display
+#### Alternative methods to measure current Home Consumption
 
-If you have a [Hildebrand Glow In Home Display](https://shop.glowmarkt.com/) and a smart meter you can retrieve live meter reading information in Home Assistant via local MQTT access - see this [Speak to the Geek article](https://www.speaktothegeek.co.uk/2022/06/hildebrand-glow-update-local-mqtt-and-home-assistant/) for setup instructions.
-
-Setup in the Energy dashboard is very similar to that for the Octopus Home Mini, except that:
-
-3. For `consumed energy` you want the name of the sensor you created to store the Hildebrand MQTT reading in, e.g. `sensor.smart_meter_electricity_energy_import`
-
-#### 3. Hildebrand Glow DCC Integration
-
-If you don't have a Hildebrand Glow IHD but do have a smart meter, you can still retrieve your daily consumption information from the central DCC smart meter database using the Hildebrand Glow API and the [Hildebrand Glow DCC Home Assistant integration](https://github.com/HandyHat/ha-hildebrandglow-dcc).  The data in the central DCC database is said to be delayed by 30 minutes but in practice has been seen to quite "lumpy" with big jumps in consumption throughout the day as meter reading updates feed through periodically into the central database.  Only a single daily consumption figure is provided so unless you are on a single daily flat rate consumption tariff this integration is not likely to be suitable for calculating daily costs.
-
-3. The daily consumption is provided by `sensor.dcc_sourced_smart_electricity_meter_usage_today`
-
-#### 4. Use an Energy Clamp or Inverter to measure Home Consumption
-
-If you use an Energy CT Clamp such as the Shelly EM on the incoming supply cable you can feed live import and export energy information into Home Assistant. Or if you have an existing Solar/Battery inverter integrated into Home Assistant the inverter could well also have a sensor that provides Grid import information that you can use in the Energy dashboard.
-
-Either of these approaches will also work regardless of whether you have a smart meter or not.
+If you don't have an Octopus Home mini you may have another way to get live or near-live daily consumption into Home Assistant such as a Hildebrand Glow In Home Display, an Energy CT Clamp such as the Shelly EM on the incoming supply cable, or your existing Solar/Battery inverter may have a sensor that provides Grid import information that you can use in the Energy dashboard.
 
 Do be aware that as you are not directly capturing the smart meter readings in Home Assistant there will always be a small measurement difference from what Octopus energy say you have used, but in practice the difference is likely to be quite small.
 
-1. Create a utility meter to store the sensor information in.  Go to [Integrations dashboard](https://my.home-assistant.io/redirect/integrations/)
-2. Click `Helpers` tab
-3. Click `Create Helper` at the bottom right-hand corner
-4. Choose `Utility Meter`
-5. Enter a name for it, e.g. `Grid Import Today`
-6. Choose the name of the sensor that is measuring your grid import. e.g. for a Shelly EM it will be `sensor.<EM channel name>_energy_total`; for a GivEnergy inverter using the GivTCP integration it will be `sensor.givtcp_XXyywwXnnn_import_energy_today_kwh`
-7. For `Meter reset cycle` chose `Daily`
-8. Click `Submit`
-9. Then add the consumption information to the Energy dashboard as per the steps for Octopus Home Mini above.  For step 3, `consumed energy`, you want the utility meter you have just created above, e.g. `sensor.grid_import_today`
+1. Create a utility meter that resets daily to store the consumption sensor information in, e.g. called `Grid Import Today`
+2. The utility meter should point to the sensor that is measuring your grid import. e.g. for a Hildebrand Glow it could be `sensor.smart_meter_electricity_energy_import`; a Shelly EM will be `sensor.<EM channel name>_energy_total`; for a GivEnergy inverter using the GivTCP integration it will be `sensor.givtcp_XXyywwXnnn_import_energy_today_kwh`
+3. Then add the consumption information to the Energy dashboard as per the steps for Octopus Home Mini above.  For step 3, `consumed energy`, you want the utility meter you have just created above, e.g. `sensor.grid_import_today`
 
 ### For Gas
 

--- a/_docs/energy_dashboard.md
+++ b/_docs/energy_dashboard.md
@@ -21,7 +21,7 @@ If you have an Octopus Home Mini and a smart electricity meter you can obtain li
 1. Go to your [energy dashboard configuration](https://my.home-assistant.io/redirect/config_energy/)
 2. Click `Add Consumption` under `Electricity Grid`
 3. For `consumed energy` you want `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_current_consumption` or `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_current_accumulative_consumption`
-4. For `Use an entity tracking the total costs` option you want `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_current_accumulative_cost`
+4. Choose the `Use an entity tracking the total costs` option and the entity is `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_current_accumulative_cost`
 
 <img src="./assets/current_consumption_electricity.png" alt="HA modal electricity example" height="500">
 
@@ -31,11 +31,11 @@ If you have an Octopus Home Mini and a smart electricity meter you can obtain li
 
 If you don't have an Octopus Home mini you may have another way to get live or near-live daily consumption into Home Assistant such as a Hildebrand Glow In Home Display, an Energy CT Clamp such as the Shelly EM on the incoming supply cable, or your existing Solar/Battery inverter may have a sensor that provides Grid import information that you can use in the Energy dashboard.
 
-Do be aware that as you are not directly capturing the smart meter readings in Home Assistant there will always be a small measurement difference from what Octopus energy say you have used, but in practice the difference is likely to be quite small.
+Do be aware that as you are not directly capturing the smart meter readings in Home Assistant the consumption does not include the standing charge and there will always be a small measurement difference from what Octopus energy say you have used, but in practice the difference is likely to be quite small.
 
 1. Create a utility meter that resets daily to store the consumption sensor information in, e.g. called `Grid Import Today`
 2. The utility meter should point to the sensor that is measuring your grid import. e.g. for a Hildebrand Glow it could be `sensor.smart_meter_electricity_energy_import`; a Shelly EM will be `sensor.<EM channel name>_energy_total`; for a GivEnergy inverter using the GivTCP integration it will be `sensor.givtcp_XXyywwXnnn_import_energy_today_kwh`
-3. Then add the consumption information to the Energy dashboard as per the steps for Octopus Home Mini above.  For step 3, `consumed energy`, you want the utility meter you have just created above, e.g. `sensor.grid_import_today`
+3. Then add the consumption information to the Energy dashboard as per the steps for Octopus Home Mini above.  For step 3, `consumed energy`, you want the utility meter you have just created above, e.g. `sensor.grid_import_today` and for step 4, choose `Use an entity with current price` and the entity is `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_current_rate`
 
 ### For Gas
 
@@ -54,7 +54,7 @@ This is only available if you have an Octopus Home Mini and a smart gas meter.
 
 If none of the methods above for feeding Current Day Consumption information into the Energy dashboard are suitable, you can add `previous consumption` sensors to the dashboard, using information retrieved via the Octopus API.  Note that the consumption information is only available on the following day so "today's" Energy dashboard will show zero values, but "yesterday's", "day before", etc will show the correct consumption for each day.
 
-Beware: Whilst you can add the previous consumption sensors directly to the Energy dashboard, they will be associated with the wrong day. This is because the Energy dashboard uses the timestamp of when the sensor updates to determine which day the data should belong to.
+**Beware: Whilst you can add the previous consumption sensors directly to the Energy dashboard, they will be associated with the wrong day.** This is because the Energy dashboard uses the timestamp of when the sensor updates to determine which day the data should belong to.
 
 Instead, you **must** use external statistics that are exported by the `previous consumption` sensors, which are broken down into hourly chunks. Please note it can take **up to 24 hours** for the external statistics to appear.
 
@@ -68,12 +68,12 @@ Instead, you **must** use external statistics that are exported by the `previous
 2. Click `Add Consumption` under `Electricity Grid`
 3. For `consumed energy` you want one of the following:
  * **`octopus_energy:`**`electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_consumption` - The total consumption reported by the meter for the previous day.  **Please note the different name to the standard entity, do NOT choose sensor.electricity_{{METER}}_{{MPAN}}_previous_accumulative_consumption.**
- * **`octopus_energy:`**`electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_consumption_peak` - The total consumption reported by the meter for the previous day that applied during peak hours. This is [disabled by default](./faq.md#there-are-entities-that-are-disabled-why-are-they-disabled-and-how-do-i-enable-them). This will only be populated if you're on a tariff with two available rates.  **Please note the different name to the standard entity.**
- * **`octopus_energy:`**`electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_consumption_off_peak` - The total consumption reported by the meter for the previous day that applied during off peak hours. This is [disabled by default](./faq.md#there-are-entities-that-are-disabled-why-are-they-disabled-and-how-do-i-enable-them). This will only be populated if you're on a tariff with two available rates.  **Please note the different name to the standard entity.**
+ * **`octopus_energy:`**`electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_consumption_peak` - The total consumption reported by the meter during peak hours for the previous day. This will only be populated if you're on a tariff with two available rates and is [disabled by default](./faq.md#there-are-entities-that-are-disabled-why-are-they-disabled-and-how-do-i-enable-them). **Please note the different name to the standard entity, do NOT choose sensor.electricity_{{METER}}_{{MPAN}}_previous_accumulative_consumption_peak.**
+ * **`octopus_energy:`**`electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_consumption_off_peak` - The total consumption reported by the meter during off-peak hours for the previous day. This will only be populated if you're on a tariff with two available rates and is [disabled by default](./faq.md#there-are-entities-that-are-disabled-why-are-they-disabled-and-how-do-i-enable-them). **Please note the different name to the standard entity, do NOT choose sensor.electricity_{{METER}}_{{MPAN}}_previous_accumulative_consumption_off_peak.**
 4. For `Use an entity tracking the total costs` option you want one of the following:
 * `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_cost` - The total cost for the previous day.
-* `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_cost_peak` - The total cost for the previous day that applied during peak hours. This is [disabled by default](./faq.md#there-are-entities-that-are-disabled-why-are-they-disabled-and-how-do-i-enable-them). This will only be populated if you're on a tariff with two available rates.
-* `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_cost_off_peak` - The total cost for the previous day that applied during off peak hours. This is [disabled by default](./faq.md#there-are-entities-that-are-disabled-why-are-they-disabled-and-how-do-i-enable-them). This will only be populated if you're on a tariff with two available rates.
+* `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_cost_peak` - The total cost for the previous day that applied during peak hours. This will only be populated if you're on a tariff with two available rates and is [disabled by default](./faq.md#there-are-entities-that-are-disabled-why-are-they-disabled-and-how-do-i-enable-them).
+* `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_cost_off_peak` - The total cost for the previous day that applied during off-peak hours. This will only be populated if you're on a tariff with two available rates and is [disabled by default](./faq.md#there-are-entities-that-are-disabled-why-are-they-disabled-and-how-do-i-enable-them).
 
 ### For Gas
 

--- a/_docs/energy_dashboard.md
+++ b/_docs/energy_dashboard.md
@@ -14,7 +14,7 @@
 
 You can only record current (i.e. today's) consumption in the Energy dashboard if you have a way of measuring live consumption in your home.
 
-There are 4 possible ways to obtain this data:
+There are 4 possible ways to obtain this consumption data:
 
 #### 1. Octopus Home Mini
 


### PR DESCRIPTION
Expanded instructions for how to setup electricity monitoring in the Home Assistant Energy dashboard:
- added other options for retrieving current consumption data using the Hildebrand Glow IHD, Hildebrand DCC API or energy sensors such as Shelly EM or an existing inverter sensor
- clarified further how to use previous day sensors in the dashboard

For #495 