### PR TITLE
Add icons for services

### DIFF
--- a/custom_components/octopus_energy/icons.json
+++ b/custom_components/octopus_energy/icons.json
@@ -1,0 +1,10 @@
+{
+    "services": {
+        "update_target_config": "mdi:invoice-edit",
+        "purge_invalid_external_statistic_ids": "mdi:delete",
+        "refresh_previous_consumption_data": "mdi:refresh",
+        "join_octoplus_saving_session_event": "mdi:leaf",
+        "spin_wheel_of_fortune": "mdi:star-circle",
+        "update_cost_tracker": "mdi:refresh"
+    }
+}


### PR DESCRIPTION
With HA 2024.2 you can now add icons to services with a simple json file, making them stand out nicely.
Here's icons for all the services.

Just like to say I've learnt a lot from your code when developing my own integration so thanks for the great work here, especially the creative use of events.