### PR TITLE
fix:api_client:Handle 'None' smart meter consumption

### DIFF
--- a/custom_components/octopus_energy/api_client/__init__.py
+++ b/custom_components/octopus_energy/api_client/__init__.py
@@ -657,12 +657,14 @@ class OctopusEnergyApiClient:
         response_body = await self.__async_read_response__(live_consumption_response, url)
 
         if (response_body is not None and "data" in response_body and "smartMeterTelemetry" in response_body["data"] and response_body["data"]["smartMeterTelemetry"] is not None and len(response_body["data"]["smartMeterTelemetry"]) > 0):
-          return list(map(lambda mp: {
-            "consumption": float(mp["consumptionDelta"]) / 1000,
-            "demand": float(mp["demand"]) if "demand" in mp and mp["demand"] is not None else None,
-            "start": parse_datetime(mp["readAt"]),
-            "end": parse_datetime(mp["readAt"]) + timedelta(minutes=30)
-          }, response_body["data"]["smartMeterTelemetry"]))
+          return [
+            {
+              "consumption": float(mp["consumptionDelta"]) / 1000,
+              "demand": float(mp["demand"]) if "demand" in mp and mp["demand"] is not None else None,
+              "start": parse_datetime(mp["readAt"]),
+              "end": parse_datetime(mp["readAt"]) + timedelta(minutes=30)
+            } for mp in response_body["data"]["smartMeterTelemetry"] if mp.get("consumptionDelta")
+          ]
         else:
           _LOGGER.debug(f"Failed to retrieve smart meter consumption data - device_id: {device_id}; period_from: {period_from}; period_to: {period_to}")
     


### PR DESCRIPTION
**tldr;** Fix `ERROR (MainThread) [custom_components.octopus_energy.coordinators.current_consumption] Unexpected error fetching current_consumption_44-11-XXXXXXXXXX data: float() argument must be a string or a real number, not 'NoneType'`

----

I had my smart meter installed today + Octopus Mini setup. I immediately looked at integrating it with Home Assistant. Whilst most of the setup went fine, Home Assistant would display the following error:

```
homeassistant-1  | 2024-02-27 15:44:30.872 ERROR (MainThread) [custom_components.octopus_energy.coordinators.current_consumption] Unexpected error fetching current_consumption_44-11-XXXXXXXXXX data: float() argument must be a string or a real number, not 'NoneType'
homeassistant-1  | Traceback (most recent call last):
homeassistant-1  |   File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 313, in _async_refresh
homeassistant-1  |     self.data = await self._async_update_data()
homeassistant-1  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
homeassistant-1  |   File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 269, in _async_update_data
homeassistant-1  |     return await self.update_method()
homeassistant-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
homeassistant-1  |   File "/config/custom_components/octopus_energy/coordinators/current_consumption.py", line 81, in async_update_data
homeassistant-1  |     hass.data[DOMAIN][account_id][key] = await async_get_live_consumption(
homeassistant-1  |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
homeassistant-1  |   File "/config/custom_components/octopus_energy/coordinators/current_consumption.py", line 39, in async_get_live_consumption
homeassistant-1  |     data = await client.async_get_smart_meter_consumption(device_id, period_from, period_to)
homeassistant-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
homeassistant-1  |   File "/config/custom_components/octopus_energy/api_client/__init__.py", line 660, in async_get_smart_meter_consumption
homeassistant-1  |     return list(map(lambda mp: {
homeassistant-1  |            ^^^^^^^^^^^^^^^^^^^^^
homeassistant-1  |   File "/config/custom_components/octopus_energy/api_client/__init__.py", line 661, in <lambda>
homeassistant-1  |     "consumption": float(mp["consumptionDelta"]) / 1000,
homeassistant-1  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
homeassistant-1  | TypeError: float() argument must be a string or a real number, not 'NoneType'
```

Handling the float() value and returning 'None' wasn't ideal as more failures would happen down the line; functions wouldn't expect to get a 'None' consumption. So it was better instead to skip any result without a `consumptionDelta` from the API response.

Looks like it's my gas consumption that is empty, likely due to the fact my account still lists my 2 old non-smart meters.

## Testing done

Modified the code straight in my Home Assistant container, restarted it, looked at logs for 2min: OK