### PR TITLE
Use MPRN to get Gas override tariff

### DIFF
--- a/custom_components/octopus_energy/sensor.py
+++ b/custom_components/octopus_energy/sensor.py
@@ -385,7 +385,7 @@ async def async_setup_default_sensors(hass: HomeAssistant, config, async_add_ent
           entities.append(OctopusEnergyGasNextRate(hass, gas_rate_coordinator, meter, point))
           entities.append(OctopusEnergyGasCurrentStandingCharge(hass, gas_standing_charges_coordinator, meter, point))
 
-          tariff_override = await async_get_tariff_override(hass, mpan, serial_number)
+          tariff_override = await async_get_tariff_override(hass, mprn, serial_number)
           previous_consumption_coordinator = await async_create_previous_consumption_and_rates_coordinator(
             hass,
             account_id,


### PR DESCRIPTION
If only gas is supplied by Octopus, MPAN is not defined, so the call fails with the error:
`cannot access local variable 'mpan' where it is not associated with a value`

By the looks of it, MPRN should be used instead.

I tried it on my local setup and the gas-only integration works fine.