### PR TITLE
Update Target Rate Sensor documentation for Target Timeframe flipped direction in window example

### DIFF
--- a/_docs/setup/target_rate.md
+++ b/_docs/setup/target_rate.md
@@ -18,7 +18,7 @@ The `from/start` time can be set in the field `The minimum time to start the dev
 
 If not specified, these default from `00:00:00` to `00:00:00` the following day.
 
-If for example you want to look at prices overnight you could set the minimum time to something like `20:00` and your maximum time to something like `05:00`. If the minimum time is "before" the maximum time, then it will treat the maximum time as the time for the following day.
+If for example you want to look at prices overnight you could set the minimum time to something like `20:00` and your maximum time to something like `05:00`. If the minimum time is "after" the maximum time, then it will treat the maximum time as the time for the following day.
 
 !!! info
 


### PR DESCRIPTION
I believe "before" is a typo here and should read "after". In the example I read the minimum time "20:00:00" as "after" maximum time "05:00:00" because 20>5. Therefore the window will be from 20:00:00 today until 05:00:00 tomororrow.