### PR TITLE
Rename electricity accumulative cost attribute

### DIFF
--- a/custom_components/octopus_energy/electricity/current_accumulative_cost.py
+++ b/custom_components/octopus_energy/electricity/current_accumulative_cost.py
@@ -150,7 +150,7 @@ class OctopusEnergyCurrentAccumulativeElectricityCost(MultiCoordinatorEntity, Oc
 
       if target_rate is None:
         self._attributes["standing_charge"] = consumption_and_cost["standing_charge"]
-        self._attributes["total_cost_without_standing_charge"] = consumption_and_cost["total_cost_without_standing_charge"]
+        self._attributes["total_without_standing_charge"] = consumption_and_cost["total_cost_without_standing_charge"]
 
     self._attributes = dict_to_typed_dict(self._attributes)
     super()._handle_coordinator_update()

--- a/custom_components/octopus_energy/electricity/previous_accumulative_cost.py
+++ b/custom_components/octopus_energy/electricity/previous_accumulative_cost.py
@@ -172,7 +172,7 @@ class OctopusEnergyPreviousAccumulativeElectricityCost(CoordinatorEntity, Octopu
 
       if target_rate is None:
         self._attributes["standing_charge"] = consumption_and_cost["standing_charge"]
-        self._attributes["total_cost_without_standing_charge"] = consumption_and_cost["total_cost_without_standing_charge"]
+        self._attributes["total_without_standing_charge"] = consumption_and_cost["total_cost_without_standing_charge"]
 
     self._attributes = dict_to_typed_dict(self._attributes)
 


### PR DESCRIPTION
Potential fix for #1127 - rename the attribute to match both equivalent gas entities and the existing documentation.

I also noticed that `electricity/previous_accumulative_cost_override.py` defines it in this format.