### PR TITLE
Remove call to print

### DIFF
--- a/custom_components/octopus_energy/target_rates/__init__.py
+++ b/custom_components/octopus_energy/target_rates/__init__.py
@@ -244,7 +244,6 @@ def calculate_intermittent_times(
   _LOGGER.debug(f'{len(applicable_rates)} applicable rates found')
 
   if ((hours_mode == CONFIG_TARGET_HOURS_MODE_EXACT and len(applicable_rates) >= total_required_rates) or hours_mode == CONFIG_TARGET_HOURS_MODE_MAXIMUM):
-    print(applicable_rates)
     applicable_rates = applicable_rates[:total_required_rates]
 
     # Make sure our rates are in ascending order before returning


### PR DESCRIPTION
This print statement clutters my HA core logs somewhat, and as it's the only one in the repo I infer that it's not intentional.