### PR TITLE
Fix threshold typo in points redemption blueprint

### DIFF
--- a/_docs/blueprints/octopus_energy_octoplus_redeem_points_for_account_credit.yml
+++ b/_docs/blueprints/octopus_energy_octoplus_redeem_points_for_account_credit.yml
@@ -15,7 +15,7 @@ blueprint:
             integration: octopus_energy
           multiple: false
     threshold:
-      name: Threshold hours
+      name: Threshold points
       description: The minimum number of redeemable points to be available for the automatic redemption to occur
       default: 1
       selector:


### PR DESCRIPTION
The blueprint threshold input is currently named 'Threshold hours' when it is actually referring to a points threshold.