### PR TITLE
fix: Replace deprecated parse_obj with model_validate

### DIFF
--- a/custom_components/octopus_energy/api_client/__init__.py
+++ b/custom_components/octopus_energy/api_client/__init__.py
@@ -908,7 +908,7 @@ class OctopusEnergyApiClient:
       raise TimeoutException()
     
     return None
-  
+
   async def async_get_heat_pump_configuration_and_status(self, account_id: str, euid: str):
     """Get a heat pump configuration and status"""
     await self.async_refresh_token()
@@ -922,20 +922,20 @@ class OctopusEnergyApiClient:
       async with client.post(url, json=payload, headers=headers) as heat_pump_response:
         response = await self.__async_read_response__(heat_pump_response, url)
 
-        if (response is not None 
-            and "data" in response 
-            and "octoHeatPumpControllerConfiguration" in response["data"] 
+        if (response is not None
+            and "data" in response
+            and "octoHeatPumpControllerConfiguration" in response["data"]
             and "octoHeatPumpControllerStatus" in response["data"]
             and "octoHeatPumpLivePerformance" in response["data"]
             and "octoHeatPumpLifetimePerformance" in response["data"]):
-          return HeatPumpResponse.parse_obj(response["data"])
-        
+          return HeatPumpResponse.model_validate(response["data"])
+
       return None
-    
+
     except TimeoutError:
       _LOGGER.warning(f'Failed to connect. Timeout of {self._timeout} exceeded.')
       raise TimeoutException()
-    
+
   async def async_set_heat_pump_flow_temp_config(self, euid: str, weather_comp_enabled: bool, weather_comp_min_temperature: float, weather_comp_max_temperature: float, fixed_flow_temperature: float):
     """Sets the flow temperature for a given heat pump zone"""
     await self.async_refresh_token()

--- a/custom_components/octopus_energy/heat_pump/__init__.py
+++ b/custom_components/octopus_energy/heat_pump/__init__.py
@@ -374,4 +374,4 @@ def mock_heat_pump_status_and_configuration():
     }
   }
 
-  return HeatPumpResponse.parse_obj(data)
+  return HeatPumpResponse.model_validate(data)

--- a/custom_components/octopus_energy/storage/heat_pump.py
+++ b/custom_components/octopus_energy/storage/heat_pump.py
@@ -12,10 +12,10 @@ async def async_load_cached_heat_pump(hass, account_id: str, euid: str) -> HeatP
     data = await store.async_load()
     if data is not None:
       _LOGGER.debug(f"Loaded cached heat pump data for {account_id}/{euid}")
-      return HeatPumpResponse.parse_obj(data)
+      return HeatPumpResponse.model_validate(data)
   except:
     return None
-  
+
 async def async_save_cached_heat_pump(hass, account_id: str, euid: str, heat_pump: HeatPumpResponse):
   if heat_pump is not None:
     store = storage.Store(hass, "2", f"octopus_energy.{account_id}_{euid}_heat_pump")

--- a/tests/unit/api_client/test_heat_pump.py
+++ b/tests/unit/api_client/test_heat_pump.py
@@ -355,7 +355,7 @@ def test_when_valid_dictionary_returned_then_it_can_be_parsed_into_heat_pump_obj
   }
 
   # Act
-  result = HeatPumpResponse.parse_obj(data)
+  result = HeatPumpResponse.model_validate(data)
 
   # Assert
   assert result is not None


### PR DESCRIPTION
Fixes https://github.com/BottlecapDave/HomeAssistant-OctopusEnergy/issues/1413