### PR TITLE
CI: Install liblzma-dev package during setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Install dependencies
-      run: sudo apt install libffi-dev libncurses5-dev zlib1g zlib1g-dev libssl-dev libreadline-dev libbz2-dev libsqlite3-dev
+      run: sudo apt install libffi-dev libncurses5-dev zlib1g zlib1g-dev libssl-dev libreadline-dev libbz2-dev libsqlite3-dev liblzma-dev
       shell: bash
     - name: asdf_install
       uses: asdf-vm/actions/install@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We use `asdf` to manage plugins.
 asdf plugin-add nodejs
 asdf plugin-add python
 sudo apt update & sudo apt upgrade
-sudo apt install libffi-dev libncurses5-dev zlib1g zlib1g-dev libssl-dev libreadline-dev libbz2-dev libsqlite3-dev
+sudo apt install libffi-dev libncurses5-dev zlib1g zlib1g-dev libssl-dev libreadline-dev libbz2-dev libsqlite3-dev liblzma-dev
 ```
 
 ## Python


### PR DESCRIPTION
```
Downloading python-build...
Cloning into '/home/runner/.asdf/plugins/python/pyenv'...
python-build 3.13.7 /home/runner/.asdf/installs/python/3.13.7
Downloading Python-3.13.7.tar.xz...
-> https://www.python.org/ftp/python/3.13.7/Python-3.13.7.tar.xz
Installing Python-3.13.7...
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import lzma
  File "/home/runner/.asdf/installs/python/3.13.7/lib/python3.13/lzma.py", line 27, in <module>
    from _lzma import *
ModuleNotFoundError: No module named '_lzma'
WARNING: The Python lzma extension was not compiled. Missing the lzma lib?
Installed Python-3.13.7 to /home/runner/.asdf/installs/python/3.13.7
```