### PR TITLE
fix: Updated minimum hacs version to 2025.1

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Octopus Energy",
   "render_readme": true,
-  "homeassistant": "2024.5.0",
+  "homeassistant": "2025.1.0",
   "hide_default_branch": true
 }


### PR DESCRIPTION
Required to support v16.2.0 as needs Pydantic v2 included in HA 2025.1 (https://github.com/BottlecapDave/HomeAssistant-OctopusEnergy/releases/tag/v16.2.0)