### PR TITLE
Handle null or non-string entity unique_ids

### DIFF
--- a/custom_components/octopus_energy/discovery.py
+++ b/custom_components/octopus_energy/discovery.py
@@ -66,7 +66,7 @@ class DiscoveryManager:
         for item in entities:
             unique_id: str = item[1].unique_id
 
-            if "octopus_energy" in unique_id:
+            if unique_id is not None and "octopus_energy" in str(unique_id):
                 continue
 
             if item[1].disabled_by is not None:

--- a/custom_components/octopus_energy/discovery.py
+++ b/custom_components/octopus_energy/discovery.py
@@ -64,9 +64,9 @@ class DiscoveryManager:
         entities = entity_registry.entities.items()
         config_entries = self._hass.config_entries.async_entries(DOMAIN, include_ignore=False)
         for item in entities:
-            unique_id: str = item[1].unique_id
+            unique_id: str = str(item[1].unique_id)
 
-            if unique_id is not None and "octopus_energy" in str(unique_id):
+            if "octopus_energy" in unique_id:
                 continue
 
             if item[1].disabled_by is not None:


### PR DESCRIPTION
The resolves issues #1484 by ensuring that unique_id values are always treated as strings during discovery

Previously, if a numeric unique_id was returned (e.g., an int), substring checks like:
`if "octopus_energy" in unique_id:`


would raise:
`TypeError: argument of type 'int' is not iterable`