### PR TITLE
fix: Input description should refer to gas.

### DIFF
--- a/_docs/blueprints/octopus_energy_gas_anomaly.yaml
+++ b/_docs/blueprints/octopus_energy_gas_anomaly.yaml
@@ -6,7 +6,7 @@ blueprint:
   input:
     consumption_entity:
       name: Consumption entity
-      description: The entity which reports the previous accumulative consumption (e.g sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_consumption)
+      description: The entity which reports the previous accumulative consumption (e.g sensor.octopus_energy_gas_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_previous_accumulative_consumption_kwh)
       selector:
         entity:
           filter:


### PR DESCRIPTION
Input description should refer to gas. 

Appended _kwh but note blueprint supports both kwh and m3 sensors.