### PR TITLE
Fix: cast schedule.max to int to resolve set-intelligent-target-time 400 error

### DIFF
--- a/custom_components/octopus_energy/api_client/__init__.py
+++ b/custom_components/octopus_energy/api_client/__init__.py
@@ -1746,7 +1746,7 @@ class OctopusEnergyApiClient:
   def __intelligent_settings_schedules__(self, schedules: List[IntelligentDeviceSettingPreferenceSchedule]) -> str:
     return ", ".join(list(map(lambda schedule: intelligent_settings_mutation_schedule
                     .format(day_of_week=schedule.dayOfWeek,
-                            target_percentage=schedule.max,
+                            target_percentage=int(schedule.max),
                             target_time=schedule.time.strftime("%H:%M")), schedules)))
 
   async def async_turn_on_intelligent_bump_charge(


### PR DESCRIPTION
When updating the intelligent target time, the Octopus Energy GraphQL 
API returns a 400 error:

"Expected value of type 'Decimal!', found 80.0"

The bug is in __intelligent_settings_schedules__ where schedule.max 
(the SoC charge target percentage) is passed as a Python float (e.g. 
80.0) in the max: field of the mutation. The API expects an integer/
Decimal, not a float. Because this field is bundled into the same 
set-intelligent-target-time mutation for each day of the week, the 
entire request is rejected.

Fix: cast schedule.max to int() before passing to the mutation template.

Fixes #1714