### PR TITLE
Fix: invert isSuspended logic so smart charge switch reflects correct state

### DIFF
--- a/custom_components/octopus_energy/intelligent/smart_charge.py
+++ b/custom_components/octopus_energy/intelligent/smart_charge.py
@@ -70,7 +70,7 @@ class OctopusEnergyIntelligentSmartCharge(CoordinatorEntity, SwitchEntity, Octop
       return self._state
 
     if settings_result.settings is not None:
-      self._state = settings_result.settings.status.isSuspended
+      self._state = not settings_result.settings.status.isSuspended
     
     self._attributes = dict_to_typed_dict(self._attributes)
     super()._handle_coordinator_update()


### PR DESCRIPTION
The smart charge switch state was being set directly from isSuspended, 
which is inverted logic:
- isSuspended = True (charging paused) → switch showed on ❌
- isSuspended = False (charging active) → switch showed off ❌

This caused the switch to flip itself off every time the coordinator 
polled Octopus and received isSuspended: False.

Fix: negate isSuspended so the switch correctly reflects whether smart 
charging is active.

Fixes #1716