### PR TITLE
hacs.json: Remove render_readme

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,5 @@
 {
   "name": "Octopus Energy",
-  "render_readme": true,
   "homeassistant": "2025.11.0",
   "hide_default_branch": true
 }


### PR DESCRIPTION
https://github.com/hacs/documentation/pull/560 and https://github.com/hacs/integration/issues/3994

Seems to have been not a thing for 2 years now