### PR TITLE
fix: Add response support to Octoplus session join services

### DIFF
--- a/_docs/services.md
+++ b/_docs/services.md
@@ -15,6 +15,8 @@ Service for joining a new power down session event. When used, it may take a cou
 | `target.entity_id`       | `no`     | The name of the target sensor whose configuration is to be updated. This should always point at the [power down events](./entities/octoplus.md#power-down-events) entity. |
 | `data.event_code`      | `no`    | The code of the event to join |
 
+This service supports an optional response. If the event is joined successfully, calling the service with `response_variable` (or `return_response: true` when using `hass.services.async_call`) will return `{"success": true}`. If the event cannot be joined (e.g. it no longer exists), the service call will fail and raise an error containing the reason, allowing the failure to be trapped in automations/scripts.
+
 #### Automation Example
 
 For an automation example, please refer to the available [blueprint](./blueprints.md#automatically-join-power-down-sessions).
@@ -31,6 +33,8 @@ Service for joining a new saving session event. When used, it may take a couple 
 | ------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------- |
 | `target.entity_id`       | `no`     | The name of the target sensor whose configuration is to be updated. This should always point at the [saving session events](./entities/octoplus.md#saving-session-events) entity. |
 | `data.event_code`      | `no`    | The code of the event to join |
+
+This service supports an optional response. If the event is joined successfully, calling the service with `response_variable` (or `return_response: true` when using `hass.services.async_call`) will return `{"success": true}`. If the event cannot be joined (e.g. it no longer exists), the service call will fail and raise an error containing the reason, allowing the failure to be trapped in automations/scripts.
 
 ### octopus_energy.redeem_octoplus_points_into_account_credit
 

--- a/custom_components/octopus_energy/event.py
+++ b/custom_components/octopus_energy/event.py
@@ -2,7 +2,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.util.dt import (utcnow)
 from homeassistant.helpers import config_validation as cv, entity_platform
 
@@ -59,6 +59,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
       ),
     ),
     "async_join_saving_session_event",
+    supports_response=SupportsResponse.OPTIONAL,
   )
   platform.async_register_entity_service(
     "join_octoplus_power_down_session_event",
@@ -71,6 +72,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
       ),
     ),
     "async_join_saving_session_event",
+    supports_response=SupportsResponse.OPTIONAL,
   )
 
   return True

--- a/custom_components/octopus_energy/octoplus/saving_sessions_events.py
+++ b/custom_components/octopus_energy/octoplus/saving_sessions_events.py
@@ -1,6 +1,7 @@
 import logging
 
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ServiceValidationError
 
 from homeassistant.components.event import (
     EventEntity,
@@ -71,6 +72,7 @@ class OctopusEnergyOctoplusSavingSessionEvents(OctopusEnergyOctoplusSensor, Even
 
     result = await self._client.async_join_octoplus_saving_session(self._account_id, event_code)
     if (result.is_successful == False):
-      raise Exception(result.errors[0])
-    else:
-      self._hass.data[DOMAIN][self._account_id][DATA_POWER_DOWN_FORCE_UPDATE] = True
+      raise ServiceValidationError(result.errors[0])
+
+    self._hass.data[DOMAIN][self._account_id][DATA_POWER_DOWN_FORCE_UPDATE] = True
+    return { "success": True }


### PR DESCRIPTION
## Summary

Hi! First-time contributor here (working through this on behalf of the batpred/predbat project) — thanks for maintaining this integration, it's a great piece of work.

This is a small fix for #1823. `join_octoplus_saving_session_event` and `join_octoplus_power_down_session_event` weren't registered with `supports_response`, so callers trying to use `return_response: true` (e.g. predbat, to trap join failures) got a `service_does_not_support_response` error before the join was even attempted.

- Registered both services with `supports_response=SupportsResponse.OPTIONAL` (backwards compatible — existing callers that don't request a response are unaffected).
- `async_join_saving_session_event` now returns `{"success": true}` on a successful join.
- On failure it still raises, so the service call fails as before — swapped the bare `Exception` for `ServiceValidationError`, matching the pattern already used elsewhere in the codebase (e.g. `points.py`, `dispatching.py`).
- Documented the response behaviour in `_docs/services.md` for both services.

## Test plan

- [x] `python -m py_compile` on the changed files
- [ ] Maintainer/CI to confirm existing unit test suite passes (couldn't get a matching Python/Home Assistant version installed locally to run it)
- [ ] Manual check: call `octopus_energy.join_octoplus_power_down_session_event` with `return_response: true` against a valid and an invalid event code

Happy to adjust naming/shape of the response payload if you'd prefer something different — just let us know.