### PR TITLE
Refactor cost tracker dependencies to use unique IDs

### DIFF
--- a/custom_components/octopus_energy/cost_tracker/base.py
+++ b/custom_components/octopus_energy/cost_tracker/base.py
@@ -1,5 +1,11 @@
 from homeassistant.helpers.device import async_entity_id_to_device
 
+
+def get_cost_tracker_unique_id(tracker_name: str, peak_type = None):
+  base_name = f"octopus_energy_cost_tracker_{tracker_name}"
+  return f"{base_name}_{peak_type}" if peak_type is not None else base_name
+
+
 class BaseCostTracker:
   def __init__(self, hass, source_entity_id: str):
 

--- a/custom_components/octopus_energy/cost_tracker/cost_tracker.py
+++ b/custom_components/octopus_energy/cost_tracker/cost_tracker.py
@@ -45,7 +45,7 @@ from . import add_consumption
 from ..cost_tracker import calculate_consumption_and_cost
 from ..utils.rate_information import get_rate_index, get_unique_rates
 from ..utils.attributes import dict_to_typed_dict
-from .base import BaseCostTracker
+from .base import BaseCostTracker, get_cost_tracker_unique_id
 from ..config.cost_tracker import build_cost_tracker_unique_id
 
 _LOGGER = logging.getLogger(__name__)
@@ -84,11 +84,10 @@ class OctopusEnergyCostTrackerSensor(CoordinatorEntity, RestoreSensor, BaseCostT
   @property
   def unique_id(self):
     """The id of the sensor."""
-    base_name = f"octopus_energy_cost_tracker_{self._config[CONFIG_COST_TRACKER_NAME]}"
-    if self._peak_type is not None:
-      return f"{base_name}_{self._peak_type}"
-    
-    return base_name
+    return get_cost_tracker_unique_id(
+      self._config[CONFIG_COST_TRACKER_NAME],
+      self._peak_type,
+    )
     
   @property
   def name(self):

--- a/custom_components/octopus_energy/cost_tracker/cost_tracker_month.py
+++ b/custom_components/octopus_energy/cost_tracker/cost_tracker_month.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.event import (
 )
 
 from homeassistant.const import (
-    Platform
+    Platform,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )

--- a/custom_components/octopus_energy/cost_tracker/cost_tracker_month.py
+++ b/custom_components/octopus_energy/cost_tracker/cost_tracker_month.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.event import (
 )
 
 from homeassistant.const import (
+    Platform
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
@@ -142,7 +143,7 @@ class OctopusEnergyCostTrackerMonthSensor(RestoreSensor, BaseCostTracker):
       _LOGGER.debug(f'Restored {self.unique_id} state: {self._state}')
 
     registry = er.async_get(self.hass)
-    self._tracked_entity_id = registry.async_get_entity_id("sensor", DOMAIN, self._tracked_entity_unique_id)
+    self._tracked_entity_id = registry.async_get_entity_id(Platform.SENSOR, DOMAIN, self._tracked_entity_unique_id)
     if self._tracked_entity_id is None:
       _LOGGER.warning(f"Unable to find tracked cost sensor with unique ID '{self._tracked_entity_unique_id}'")
       return

--- a/custom_components/octopus_energy/cost_tracker/cost_tracker_month.py
+++ b/custom_components/octopus_energy/cost_tracker/cost_tracker_month.py
@@ -4,6 +4,7 @@ import logging
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity import generate_entity_id
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import (now)
 
 from homeassistant.components.sensor import (
@@ -40,7 +41,7 @@ _LOGGER = logging.getLogger(__name__)
 class OctopusEnergyCostTrackerMonthSensor(RestoreSensor, BaseCostTracker):
   """Sensor for calculating the cost for a given sensor over the course of a month."""
 
-  def __init__(self, hass: HomeAssistant, config_entry, config, device_entry, tracked_entity_id: str, peak_type = None):
+  def __init__(self, hass: HomeAssistant, config_entry, config, device_entry, tracked_entity_unique_id: str, peak_type = None):
     """Init sensor."""
     # Pass coordinator to base class
 
@@ -50,7 +51,8 @@ class OctopusEnergyCostTrackerMonthSensor(RestoreSensor, BaseCostTracker):
     self._attributes["total_consumption"] = 0
     self._attributes["accumulated_data"] = []
     self._last_reset = None
-    self._tracked_entity_id = tracked_entity_id
+    self._tracked_entity_unique_id = tracked_entity_unique_id
+    self._tracked_entity_id = None
     self._config_entry = config_entry
     self._peak_type = peak_type
     
@@ -138,6 +140,12 @@ class OctopusEnergyCostTrackerMonthSensor(RestoreSensor, BaseCostTracker):
       self._attributes.update(self._config)
     
       _LOGGER.debug(f'Restored {self.unique_id} state: {self._state}')
+
+    registry = er.async_get(self.hass)
+    self._tracked_entity_id = registry.async_get_entity_id("sensor", DOMAIN, self._tracked_entity_unique_id)
+    if self._tracked_entity_id is None:
+      _LOGGER.warning(f"Unable to find tracked cost sensor with unique ID '{self._tracked_entity_unique_id}'")
+      return
 
     self.async_on_remove(
       async_track_state_change_event(

--- a/custom_components/octopus_energy/cost_tracker/cost_tracker_week.py
+++ b/custom_components/octopus_energy/cost_tracker/cost_tracker_week.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.event import (
 )
 
 from homeassistant.const import (
+    Platform,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
@@ -141,7 +142,7 @@ class OctopusEnergyCostTrackerWeekSensor(RestoreSensor, BaseCostTracker):
       _LOGGER.debug(f'Restored {self.unique_id} state: {self._state}')
 
     registry = er.async_get(self.hass)
-    self._tracked_entity_id = registry.async_get_entity_id("sensor", DOMAIN, self._tracked_entity_unique_id)
+    self._tracked_entity_id = registry.async_get_entity_id(Platform.SENSOR, DOMAIN, self._tracked_entity_unique_id)
     if self._tracked_entity_id is None:
       _LOGGER.warning(f"Unable to find tracked cost sensor with unique ID '{self._tracked_entity_unique_id}'")
       return

--- a/custom_components/octopus_energy/cost_tracker/cost_tracker_week.py
+++ b/custom_components/octopus_energy/cost_tracker/cost_tracker_week.py
@@ -4,6 +4,7 @@ import logging
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity import generate_entity_id
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import (now)
 
 from homeassistant.components.sensor import (
@@ -40,7 +41,7 @@ _LOGGER = logging.getLogger(__name__)
 class OctopusEnergyCostTrackerWeekSensor(RestoreSensor, BaseCostTracker):
   """Sensor for calculating the cost for a given sensor over the course of a week."""
 
-  def __init__(self, hass: HomeAssistant, config_entry, config, device_entry, tracked_entity_id: str, peak_type = None):
+  def __init__(self, hass: HomeAssistant, config_entry, config, device_entry, tracked_entity_unique_id: str, peak_type = None):
     """Init sensor."""
     # Pass coordinator to base class
 
@@ -50,7 +51,8 @@ class OctopusEnergyCostTrackerWeekSensor(RestoreSensor, BaseCostTracker):
     self._attributes["total_consumption"] = 0
     self._attributes["accumulated_data"] = []
     self._last_reset = None
-    self._tracked_entity_id = tracked_entity_id
+    self._tracked_entity_unique_id = tracked_entity_unique_id
+    self._tracked_entity_id = None
     self._config_entry = config_entry
     self._peak_type = peak_type
     
@@ -137,6 +139,12 @@ class OctopusEnergyCostTrackerWeekSensor(RestoreSensor, BaseCostTracker):
       self._attributes.update(self._config)
     
       _LOGGER.debug(f'Restored {self.unique_id} state: {self._state}')
+
+    registry = er.async_get(self.hass)
+    self._tracked_entity_id = registry.async_get_entity_id("sensor", DOMAIN, self._tracked_entity_unique_id)
+    if self._tracked_entity_id is None:
+      _LOGGER.warning(f"Unable to find tracked cost sensor with unique ID '{self._tracked_entity_unique_id}'")
+      return
 
     self.async_on_remove(
       async_track_state_change_event(

--- a/custom_components/octopus_energy/sensor.py
+++ b/custom_components/octopus_energy/sensor.py
@@ -734,8 +734,6 @@ async def async_setup_cost_sensors(hass: HomeAssistant, entry, config, async_add
 
   mpan = config[CONFIG_COST_TRACKER_MPAN]
 
-  registry = er.async_get(hass)
-
   now = utcnow()
   for point in account_info["electricity_meter_points"]:
     tariff = get_active_tariff(now, point["agreements"])
@@ -762,12 +760,11 @@ async def async_setup_cost_sensors(hass: HomeAssistant, entry, config, async_add
             device_entry = device_registry.async_get(device_id)
 
           sensor = OctopusEnergyCostTrackerSensor(hass, coordinator, entry, config, device_entry)
-          sensor_entity_id = registry.async_get_entity_id("sensor", DOMAIN, sensor.unique_id)
 
           entities = [
             sensor,
-            OctopusEnergyCostTrackerWeekSensor(hass, entry, config, device_entry, sensor_entity_id if sensor_entity_id is not None else sensor.entity_id),
-            OctopusEnergyCostTrackerMonthSensor(hass, entry, config, device_entry, sensor_entity_id if sensor_entity_id is not None else sensor.entity_id),
+            OctopusEnergyCostTrackerWeekSensor(hass, entry, config, device_entry, sensor.unique_id),
+            OctopusEnergyCostTrackerMonthSensor(hass, entry, config, device_entry, sensor.unique_id),
           ]
           
           debug_override = await async_get_meter_debug_override(hass, mpan, serial_number)
@@ -777,11 +774,10 @@ async def async_setup_cost_sensors(hass: HomeAssistant, entry, config, async_add
               peak_type = get_peak_type(total_unique_rates, unique_rate_index)
               if peak_type is not None:
                 peak_sensor = OctopusEnergyCostTrackerSensor(hass, coordinator, entry, config, device_entry, peak_type)
-                peak_sensor_entity_id = registry.async_get_entity_id("sensor", DOMAIN, peak_sensor.unique_id)
                 
                 entities.append(peak_sensor)
-                entities.append(OctopusEnergyCostTrackerWeekSensor(hass, entry, config, device_entry, peak_sensor_entity_id if peak_sensor_entity_id is not None else f"sensor.{peak_sensor.unique_id}", peak_type))
-                entities.append(OctopusEnergyCostTrackerMonthSensor(hass, entry, config, device_entry, peak_sensor_entity_id if peak_sensor_entity_id is not None else f"sensor.{peak_sensor.unique_id}", peak_type))
+                entities.append(OctopusEnergyCostTrackerWeekSensor(hass, entry, config, device_entry, peak_sensor.unique_id, peak_type))
+                entities.append(OctopusEnergyCostTrackerMonthSensor(hass, entry, config, device_entry, peak_sensor.unique_id, peak_type))
 
           async_add_entities(entities)
           break

--- a/tests/unit/cost_tracker/test_tracker_dependencies.py
+++ b/tests/unit/cost_tracker/test_tracker_dependencies.py
@@ -1,0 +1,156 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, call, patch
+
+import pytest
+from homeassistant.components.sensor import RestoreSensor
+
+from custom_components.octopus_energy import sensor as sensor_module
+from custom_components.octopus_energy.const import (
+  CONFIG_ACCOUNT_ID,
+  CONFIG_COST_TRACKER_MPAN,
+  CONFIG_COST_TRACKER_NAME,
+  CONFIG_COST_TRACKER_TARGET_ENTITY_ID,
+  DATA_ACCOUNT,
+  DATA_CLIENT,
+  DATA_ELECTRICITY_RATES_COORDINATOR_KEY,
+  DOMAIN,
+)
+from custom_components.octopus_energy.cost_tracker.base import get_cost_tracker_unique_id
+from custom_components.octopus_energy.cost_tracker.cost_tracker_month import OctopusEnergyCostTrackerMonthSensor
+from custom_components.octopus_energy.cost_tracker.cost_tracker_week import OctopusEnergyCostTrackerWeekSensor
+
+
+@pytest.mark.parametrize(
+  ("peak_type", "expected_unique_id"),
+  [
+    (None, "octopus_energy_cost_tracker_washing_machine"),
+    ("peak", "octopus_energy_cost_tracker_washing_machine_peak"),
+  ],
+)
+def test_cost_tracker_unique_id_is_unchanged(peak_type, expected_unique_id):
+  assert get_cost_tracker_unique_id("washing_machine", peak_type) == expected_unique_id
+
+
+@pytest.mark.asyncio
+async def test_setup_cost_sensors_passes_daily_unique_ids_to_accumulators():
+  account_id = "A-123"
+  mpan = "1234567890123"
+  serial_number = "S123456"
+  config = {
+    CONFIG_ACCOUNT_ID: account_id,
+    CONFIG_COST_TRACKER_MPAN: mpan,
+    CONFIG_COST_TRACKER_NAME: "washing_machine",
+    CONFIG_COST_TRACKER_TARGET_ENTITY_ID: None,
+  }
+
+  hass = SimpleNamespace(
+    data={
+      DOMAIN: {
+        account_id: {
+          DATA_ACCOUNT: SimpleNamespace(
+            account={
+              "electricity_meter_points": [
+                {
+                  "mpan": mpan,
+                  "agreements": [],
+                  "meters": [{"serial_number": serial_number}],
+                }
+              ]
+            }
+          ),
+          DATA_CLIENT: Mock(),
+          DATA_ELECTRICITY_RATES_COORDINATOR_KEY.format(mpan, serial_number): Mock(),
+        }
+      }
+    }
+  )
+
+  daily_sensor = SimpleNamespace(
+    unique_id="octopus_energy_cost_tracker_washing_machine"
+  )
+  peak_sensor = SimpleNamespace(
+    unique_id="octopus_energy_cost_tracker_washing_machine_peak"
+  )
+
+  daily_sensor_class = Mock(side_effect=[daily_sensor, peak_sensor])
+  week_sensor_class = Mock()
+  month_sensor_class = Mock()
+  async_add_entities = Mock()
+  entry = Mock()
+
+  with (
+    patch.object(sensor_module, "get_active_tariff", return_value=Mock()),
+    patch.object(sensor_module.dr, "async_get", return_value=Mock()),
+    patch.object(sensor_module.er, "async_get", return_value=Mock()),
+    patch.object(sensor_module, "OctopusEnergyCostTrackerSensor", daily_sensor_class),
+    patch.object(sensor_module, "OctopusEnergyCostTrackerWeekSensor", week_sensor_class),
+    patch.object(sensor_module, "OctopusEnergyCostTrackerMonthSensor", month_sensor_class),
+    patch.object(sensor_module, "async_get_meter_debug_override", new=AsyncMock(return_value=None)),
+    patch.object(sensor_module, "get_unique_electricity_rates", new=AsyncMock(return_value=1)),
+    patch.object(sensor_module, "has_peak_rates", return_value=True),
+    patch.object(sensor_module, "get_peak_type", return_value="peak"),
+  ):
+    await sensor_module.async_setup_cost_sensors(hass, entry, config, async_add_entities)
+
+  assert week_sensor_class.call_args_list == [
+    call(hass, entry, config, None, daily_sensor.unique_id),
+    call(hass, entry, config, None, peak_sensor.unique_id, "peak"),
+  ]
+  assert month_sensor_class.call_args_list == [
+    call(hass, entry, config, None, daily_sensor.unique_id),
+    call(hass, entry, config, None, peak_sensor.unique_id, "peak"),
+  ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+  ("sensor_class", "module_name"),
+  [
+    (
+      OctopusEnergyCostTrackerWeekSensor,
+      "custom_components.octopus_energy.cost_tracker.cost_tracker_week",
+    ),
+    (
+      OctopusEnergyCostTrackerMonthSensor,
+      "custom_components.octopus_energy.cost_tracker.cost_tracker_month",
+    ),
+  ],
+)
+async def test_accumulator_resolves_current_entity_id_from_unique_id(sensor_class, module_name):
+  tracked_unique_id = "octopus_energy_cost_tracker_washing_machine"
+  current_entity_id = "sensor.renamed_washing_machine_cost"
+  config = {
+    CONFIG_COST_TRACKER_NAME: "washing_machine",
+    CONFIG_COST_TRACKER_TARGET_ENTITY_ID: "sensor.washing_machine_energy",
+  }
+
+  hass = Mock()
+  config_entry = SimpleNamespace(entry_id="entry-id")
+  registry = Mock()
+  registry.async_get_entity_id.return_value = current_entity_id
+
+  with (
+    patch(
+      "custom_components.octopus_energy.cost_tracker.base.async_entity_id_to_device",
+      return_value=None,
+    ),
+    patch(f"{module_name}.generate_entity_id", return_value="sensor.accumulator"),
+    patch(f"{module_name}.er.async_get", return_value=registry),
+    patch.object(RestoreSensor, "async_added_to_hass", new=AsyncMock()),
+    patch(f"{module_name}.async_track_state_change_event", return_value=Mock()) as track_state,
+    patch(
+      f"{module_name}.async_track_entity_registry_updated_event",
+      return_value=Mock(),
+    ) as track_registry,
+  ):
+    tracker = sensor_class(hass, config_entry, config, None, tracked_unique_id)
+    tracker.async_get_last_state = AsyncMock(return_value=None)
+    tracker.async_get_last_sensor_data = AsyncMock(return_value=None)
+    tracker.async_on_remove = Mock()
+
+    await tracker.async_added_to_hass()
+
+  registry.async_get_entity_id.assert_called_once_with("sensor", DOMAIN, tracked_unique_id)
+  assert tracker._tracked_entity_id == current_entity_id
+  assert track_state.call_args.args[1] == [current_entity_id]
+  assert track_registry.call_args.args[1] == [current_entity_id]


### PR DESCRIPTION
While expanding the scope of changes for #1821, I found that weekly and monthly cost trackers currently keep a reference to the daily tracker by `entity_id`. This works while that ID stays fixed, but it couples the internal relationship to a user-facing identifier and requires setup-time registry lookups/fallbacks.

This changes that dependency to use the daily tracker's stable `unique_id`, resolving the current `entity_id` only when the accumulator is added and needs to attach Home Assistant listeners.

Why:
- avoids weekly/monthly trackers breaking if the daily entity ID is renamed or recreated
- removes the fallback that assumes `sensor.<unique_id>` is the entity ID
- keeps internal identity based on the integration's stable `unique_id`

No user-facing behaviour changes: existing `unique_id`s, entity names and explicit `generate_entity_id` behaviour are unchanged, and no migration is required. This is wholly independent of any other entity ID or naming changes.

Tests cover normal and peak setup wiring, and verify weekly/monthly resolve a renamed daily `entity_id` from the unchanged `unique_id`.