### PR TITLE
fix: Use update listener for config entry reloads

### DIFF
--- a/custom_components/octopus_energy/config_flow.py
+++ b/custom_components/octopus_energy/config_flow.py
@@ -284,7 +284,7 @@ class OctopusEnergyConfigFlow(ConfigFlow, domain=DOMAIN):
     errors = await async_validate_main_config(config, account_ids)
 
     if len(errors) < 1 and user_input is not None:
-      return self.async_update_reload_and_abort(
+      return self.async_update_and_abort(
         self._get_reconfigure_entry(),
         data_updates=config,
       )
@@ -416,7 +416,7 @@ class OctopusEnergyConfigFlow(ConfigFlow, domain=DOMAIN):
     errors = validate_cost_tracker_config(config, account_info.account, now)
 
     if len(errors) < 1 and user_input is not None:
-      return self.async_update_reload_and_abort(
+      return self.async_update_and_abort(
         self._get_reconfigure_entry(),
         data_updates=config,
       )
@@ -517,7 +517,7 @@ class OctopusEnergyConfigFlow(ConfigFlow, domain=DOMAIN):
     errors = await async_validate_tariff_comparison_config(config, account_info.account, now, client)
 
     if len(errors) < 1 and user_input is not None:
-      return self.async_update_reload_and_abort(
+      return self.async_update_and_abort(
         self._get_reconfigure_entry(),
         data_updates=config,
       )

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -2,7 +2,7 @@ pytest
 pytest-socket
 pytest-asyncio
 mock
-homeassistant==2025.8.3
+homeassistant==2025.11.0
 pydantic
 psutil-home-assistant
 sqlalchemy

--- a/tests/unit/config/test_config_flow.py
+++ b/tests/unit/config/test_config_flow.py
@@ -1,0 +1,97 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from custom_components.octopus_energy.config_flow import OctopusEnergyConfigFlow
+from custom_components.octopus_energy.const import (
+  CONFIG_ACCOUNT_ID,
+  CONFIG_KIND,
+  CONFIG_KIND_ACCOUNT,
+  CONFIG_KIND_TARIFF_COMPARISON,
+  CONFIG_MAIN_API_KEY,
+  CONFIG_TARIFF_COMPARISON_MPAN_MPRN,
+  CONFIG_TARIFF_COMPARISON_NAME,
+  CONFIG_TARIFF_COMPARISON_PRODUCT_CODE,
+  CONFIG_TARIFF_COMPARISON_TARIFF_CODE,
+  DATA_ACCOUNT,
+  DATA_CLIENT,
+  DOMAIN,
+)
+
+
+def configure_update_helpers(flow: OctopusEnergyConfigFlow) -> None:
+  flow.async_update_and_abort = Mock(return_value={"type": "abort"})
+  flow.async_update_reload_and_abort = Mock(return_value={"type": "abort"})
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_account_updates_without_explicit_reload():
+  config_entry = SimpleNamespace(data={
+    CONFIG_KIND: CONFIG_KIND_ACCOUNT,
+    CONFIG_ACCOUNT_ID: "A-TEST",
+    CONFIG_MAIN_API_KEY: "old-api-key",
+  })
+  flow = OctopusEnergyConfigFlow()
+  flow._get_reconfigure_entry = Mock(return_value=config_entry)
+  configure_update_helpers(flow)
+
+  with patch(
+    "custom_components.octopus_energy.config_flow.async_validate_main_config",
+    new=AsyncMock(return_value={}),
+  ):
+    result = await flow.async_step_reconfigure_account({
+      CONFIG_MAIN_API_KEY: "new-api-key",
+    })
+
+  assert result == {"type": "abort"}
+  flow.async_update_and_abort.assert_called_once_with(
+    config_entry,
+    data_updates={
+      CONFIG_KIND: CONFIG_KIND_ACCOUNT,
+      CONFIG_ACCOUNT_ID: "A-TEST",
+      CONFIG_MAIN_API_KEY: "new-api-key",
+    },
+  )
+  flow.async_update_reload_and_abort.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_tariff_comparison_updates_without_explicit_reload():
+  config_entry = SimpleNamespace(data={
+    CONFIG_KIND: CONFIG_KIND_TARIFF_COMPARISON,
+    CONFIG_ACCOUNT_ID: "A-TEST",
+    CONFIG_TARIFF_COMPARISON_NAME: "Current tariff",
+    CONFIG_TARIFF_COMPARISON_MPAN_MPRN: "1234567890123",
+    CONFIG_TARIFF_COMPARISON_PRODUCT_CODE: "CURRENT-PRODUCT",
+    CONFIG_TARIFF_COMPARISON_TARIFF_CODE: "CURRENT-TARIFF",
+  })
+  flow = OctopusEnergyConfigFlow()
+  flow.hass = SimpleNamespace(data={
+    DOMAIN: {
+      "A-TEST": {
+        DATA_ACCOUNT: SimpleNamespace(account={}),
+        DATA_CLIENT: Mock(),
+      },
+    },
+  })
+  flow._get_reconfigure_entry = Mock(return_value=config_entry)
+  configure_update_helpers(flow)
+
+  with patch(
+    "custom_components.octopus_energy.config_flow.async_validate_tariff_comparison_config",
+    new=AsyncMock(return_value={}),
+  ):
+    result = await flow.async_step_reconfigure_tariff_comparison({
+      CONFIG_TARIFF_COMPARISON_NAME: "Updated tariff",
+    })
+
+  assert result == {"type": "abort"}
+  flow.async_update_and_abort.assert_called_once_with(
+    config_entry,
+    data_updates={
+      **config_entry.data,
+      CONFIG_TARIFF_COMPARISON_NAME: "Updated tariff",
+    },
+  )
+  flow.async_update_reload_and_abort.assert_not_called()

--- a/tests/unit/cost_tracker/test_config_flow.py
+++ b/tests/unit/cost_tracker/test_config_flow.py
@@ -121,6 +121,7 @@ async def test_reconfigure_cost_tracker_preserves_existing_target_entity():
   flow = create_flow()
   config_entry = create_config_entry("sensor.lounge_cooling_energy")
   flow._get_reconfigure_entry = Mock(return_value=config_entry)
+  flow.async_update_and_abort = Mock(return_value={"type": "abort"})
   flow.async_update_reload_and_abort = Mock(return_value={"type": "abort"})
   user_input = create_user_input("sensor.kitchen_heating_energy")
 
@@ -130,9 +131,11 @@ async def test_reconfigure_cost_tracker_preserves_existing_target_entity():
   ):
     await flow.async_step_reconfigure_cost_tracker(user_input)
 
-  data_updates = flow.async_update_reload_and_abort.call_args.kwargs["data_updates"]
+  flow.async_update_and_abort.assert_called_once()
+  flow.async_update_reload_and_abort.assert_not_called()
+  data_updates = flow.async_update_and_abort.call_args.kwargs["data_updates"]
   assert data_updates[CONFIG_COST_TRACKER_TARGET_ENTITY_ID] == "sensor.lounge_cooling_energy"
-  assert "unique_id" not in flow.async_update_reload_and_abort.call_args.kwargs
+  assert "unique_id" not in flow.async_update_and_abort.call_args.kwargs
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1843.

## What changed

The three reconfigure flows currently call `async_update_reload_and_abort()`, while every config entry also registers `options_update_listener()` to reload after an update. Home Assistant 2026.6 started warning about that combination because it can schedule the same reload twice.

This changes the account, cost tracker and tariff comparison flows to use `async_update_and_abort()`. The entry is still updated in the same way, but the existing listener is now the single place responsible for reloading it.

I also moved the test dependency from Home Assistant 2025.8.3 to 2025.11.0. The latter is already the minimum version declared in `hacs.json` and is the first supported baseline here that provides `async_update_and_abort()`. Regression tests cover all three reconfigure paths and check that the explicit reload helper is no longer used.

## Validation

- 695 unit tests passed on Python 3.13 with Home Assistant 2025.11.0
- 695 unit tests passed on Python 3.14 with Home Assistant 2025.11.0
- 695 unit tests passed on Python 3.14 with Home Assistant 2026.8.3
- `npm run build` passed