### PR TITLE
fix: Handle missing current electricity rates

### DIFF
--- a/custom_components/octopus_energy/electricity/__init__.py
+++ b/custom_components/octopus_energy/electricity/__init__.py
@@ -4,6 +4,14 @@ from ..utils.conversions import pence_to_pounds_pence, pence_to_pounds_pence_acc
 
 _LOGGER = logging.getLogger(__name__)
 
+class MissingElectricityRateError(Exception):
+  """Raised when consumption cannot be matched to an electricity rate."""
+
+  def __init__(self, start, end):
+    self.start = start
+    self.end = end
+    super().__init__(f"Failed to find rate for consumption between {start} and {end}")
+
 def __get_to(item):
     return (item["end"].timestamp(), item["end"].fold)
 
@@ -39,7 +47,7 @@ def calculate_electricity_consumption_and_cost(
         try:
           rate = next(r for r in rate_data if r["start"] == consumption_from and r["end"] == consumption_to)
         except StopIteration:
-          raise Exception(f"Failed to find rate for consumption between {consumption_from} and {consumption_to}")
+          raise MissingElectricityRateError(consumption_from, consumption_to)
 
         value = rate["value_inc_vat"]
 

--- a/custom_components/octopus_energy/electricity/current_accumulative_consumption.py
+++ b/custom_components/octopus_energy/electricity/current_accumulative_consumption.py
@@ -23,7 +23,7 @@ from .base import (OctopusEnergyElectricitySensor)
 from ..utils.attributes import dict_to_typed_dict
 from ..utils.rate_information import get_peak_name, get_rate_index, get_unique_rates
 
-from . import calculate_electricity_consumption_and_cost
+from . import calculate_electricity_consumption_and_cost, MissingElectricityRateError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,6 +36,7 @@ class OctopusEnergyCurrentAccumulativeElectricityConsumption(MultiCoordinatorEnt
 
     self._state = None
     self._last_reset = None
+    self._missing_rate_error = None
     
     self._rates_coordinator = rates_coordinator
     self._standing_charge_coordinator = standing_charge_coordinator
@@ -101,7 +102,7 @@ class OctopusEnergyCurrentAccumulativeElectricityConsumption(MultiCoordinatorEnt
 
   @property
   def native_value(self):
-    return self._state
+    return None if self._missing_rate_error is not None else self._state
   
   @callback
   def _handle_coordinator_update(self) -> None:
@@ -118,15 +119,28 @@ class OctopusEnergyCurrentAccumulativeElectricityConsumption(MultiCoordinatorEnt
       unique_rate_index = get_rate_index(len(unique_rates), self._peak_type)
       target_rate = unique_rates[unique_rate_index] if unique_rate_index is not None else None
 
-    consumption_and_cost = calculate_electricity_consumption_and_cost(
-      consumption_data,
-      rate_data,
-      standing_charge if target_rate is None else 0,
-      None, # We want to recalculate
-      target_rate=target_rate
-    )
+    try:
+      consumption_and_cost = calculate_electricity_consumption_and_cost(
+        consumption_data,
+        rate_data,
+        standing_charge if target_rate is None else 0,
+        None, # We want to recalculate
+        target_rate=target_rate
+      )
+    except MissingElectricityRateError as error:
+      if self._missing_rate_error is None:
+        _LOGGER.warning(
+          "Unable to calculate current electricity consumption for '%s/%s': %s. The sensor will recover when complete rate data is available",
+          self._mpan,
+          self._serial_number,
+          error,
+        )
+      self._missing_rate_error = error
+      super()._handle_coordinator_update()
+      return
 
     if (consumption_and_cost is not None):
+      self._missing_rate_error = None
       _LOGGER.debug(f"Calculated previous electricity consumption for '{self._mpan}/{self._serial_number}'...")
 
       self._state = consumption_and_cost["total_consumption"]

--- a/custom_components/octopus_energy/electricity/current_accumulative_cost.py
+++ b/custom_components/octopus_energy/electricity/current_accumulative_cost.py
@@ -17,6 +17,7 @@ from homeassistant.util.dt import (now)
 
 from . import (
   calculate_electricity_consumption_and_cost,
+  MissingElectricityRateError,
 )
 
 from ..coordinators import MultiCoordinatorEntity
@@ -38,6 +39,7 @@ class OctopusEnergyCurrentAccumulativeElectricityCost(MultiCoordinatorEntity, Oc
 
     self._state = None
     self._last_reset = None
+    self._missing_rate_error = None
     self._rates_coordinator = rates_coordinator
     self._standing_charge_coordinator = standing_charge_coordinator
     self._peak_type = peak_type
@@ -102,7 +104,7 @@ class OctopusEnergyCurrentAccumulativeElectricityCost(MultiCoordinatorEntity, Oc
 
   @property
   def native_value(self):
-    return self._state
+    return None if self._missing_rate_error is not None else self._state
   
   @callback
   def _handle_coordinator_update(self) -> None:
@@ -119,15 +121,28 @@ class OctopusEnergyCurrentAccumulativeElectricityCost(MultiCoordinatorEntity, Oc
       unique_rate_index = get_rate_index(len(unique_rates), self._peak_type)
       target_rate = unique_rates[unique_rate_index] if unique_rate_index is not None else None
 
-    consumption_and_cost = calculate_electricity_consumption_and_cost(
-      consumption_data,
-      rate_data,
-      standing_charge if target_rate is None else 0,
-      None, # We want to always recalculate
-      target_rate=target_rate
-    )
+    try:
+      consumption_and_cost = calculate_electricity_consumption_and_cost(
+        consumption_data,
+        rate_data,
+        standing_charge if target_rate is None else 0,
+        None, # We want to always recalculate
+        target_rate=target_rate
+      )
+    except MissingElectricityRateError as error:
+      if self._missing_rate_error is None:
+        _LOGGER.warning(
+          "Unable to calculate current electricity cost for '%s/%s': %s. The sensor will recover when complete rate data is available",
+          self._mpan,
+          self._serial_number,
+          error,
+        )
+      self._missing_rate_error = error
+      super()._handle_coordinator_update()
+      return
 
     if (consumption_and_cost is not None):
+      self._missing_rate_error = None
       _LOGGER.debug(f"Calculated current electricity consumption cost for '{self._mpan}/{self._serial_number}'...")
       self._last_reset = consumption_and_cost["last_reset"]
       self._state = consumption_and_cost["total_cost"]

--- a/tests/unit/electricity/test_calculate_electricity_consumption_and_cost.py
+++ b/tests/unit/electricity/test_calculate_electricity_consumption_and_cost.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 import pytest
 
 from unit import (create_consumption_data, create_rate_data)
-from custom_components.octopus_energy.electricity import calculate_electricity_consumption_and_cost
+from custom_components.octopus_energy.electricity import calculate_electricity_consumption_and_cost, MissingElectricityRateError
 
 @pytest.mark.asyncio
 async def test_when_electricity_consumption_is_none_then_no_calculation_is_returned():
@@ -46,6 +46,29 @@ async def test_when_electricity_rates_is_none_then_no_calculation_is_returned():
 
   # Assert
   assert result is None
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("missing_rate_index", [0, 1, 2], ids=["first", "middle", "last"])
+async def test_when_electricity_rate_is_missing_then_exception_is_raised(missing_rate_index):
+  # Arrange
+  period_from = datetime.strptime("2022-02-28T00:00:00Z", "%Y-%m-%dT%H:%M:%S%z")
+  period_to = datetime.strptime("2022-02-28T01:30:00Z", "%Y-%m-%dT%H:%M:%S%z")
+  consumption_data = create_consumption_data(period_from, period_to)
+  rate_data = create_rate_data(period_from, period_to, [50])
+  missing_rate = rate_data.pop(missing_rate_index)
+
+  # Act/Assert
+  with pytest.raises(MissingElectricityRateError) as raised_exception:
+    calculate_electricity_consumption_and_cost(
+      consumption_data,
+      rate_data,
+      10.1,
+      None
+    )
+
+  assert str(raised_exception.value) == f"Failed to find rate for consumption between {missing_rate['start']} and {missing_rate['end']}"
+  assert raised_exception.value.start == missing_rate["start"]
+  assert raised_exception.value.end == missing_rate["end"]
 
 @pytest.mark.asyncio
 async def test_when_electricity_consumption_is_before_latest_date_then_no_calculation_is_returned():
@@ -347,4 +370,3 @@ async def test_electricity_consumption_with_website_data():
     
     assert "consumption" in item
     assert item["consumption"] == consumption_data[index]["consumption"]
-  

--- a/tests/unit/electricity/test_current_accumulative_entities.py
+++ b/tests/unit/electricity/test_current_accumulative_entities.py
@@ -1,0 +1,110 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+import logging
+
+import pytest
+
+from unit import create_consumption_data, create_rate_data
+from custom_components.octopus_energy.electricity import current_accumulative_consumption, current_accumulative_cost
+from custom_components.octopus_energy.electricity.current_accumulative_consumption import OctopusEnergyCurrentAccumulativeElectricityConsumption
+from custom_components.octopus_energy.electricity.current_accumulative_cost import OctopusEnergyCurrentAccumulativeElectricityCost
+
+
+def create_entity(entity_class):
+  period_from = datetime.strptime("2022-02-28T00:00:00Z", "%Y-%m-%dT%H:%M:%S%z")
+  period_to = datetime.strptime("2022-02-28T01:30:00Z", "%Y-%m-%dT%H:%M:%S%z")
+
+  hass = MagicMock()
+  hass.states.async_entity_ids.return_value = []
+
+  consumption_coordinator = MagicMock()
+  consumption_coordinator.data = SimpleNamespace(data=create_consumption_data(period_from, period_to))
+
+  rates_coordinator = MagicMock()
+  rates_coordinator.data = SimpleNamespace(rates=create_rate_data(period_from, period_to, [50]))
+
+  standing_charge_coordinator = MagicMock()
+  standing_charge_coordinator.data = SimpleNamespace(standing_charge={"value_inc_vat": 10.1})
+
+  entity = entity_class(
+    hass,
+    consumption_coordinator,
+    rates_coordinator,
+    standing_charge_coordinator,
+    {
+      "serial_number": "test-serial-number",
+      "is_export": False,
+      "is_smart_meter": True,
+      "manufacturer": "test-manufacturer",
+      "model": "test-model",
+      "firmware": "test-firmware",
+    },
+    {"mpan": "test-mpan"}
+  )
+  entity.async_write_ha_state = MagicMock()
+
+  return entity, rates_coordinator
+
+
+@pytest.mark.parametrize("entity_class", [
+  OctopusEnergyCurrentAccumulativeElectricityConsumption,
+  OctopusEnergyCurrentAccumulativeElectricityCost,
+])
+def test_when_rate_is_missing_then_repeated_updates_are_suppressed_and_complete_rates_recover(entity_class, caplog):
+  # Arrange
+  entity, rates_coordinator = create_entity(entity_class)
+  entity._handle_coordinator_update()
+  previous_value = entity.native_value
+  previous_state = entity._state
+  previous_last_reset = entity._last_reset
+  previous_attributes = entity._attributes
+
+  missing_rate = rates_coordinator.data.rates.pop(1)
+
+  # Act
+  with caplog.at_level(logging.WARNING):
+    for _ in range(3):
+      entity._handle_coordinator_update()
+
+  # Assert
+  assert entity.native_value is None
+  assert entity._state == previous_state
+  assert entity._last_reset == previous_last_reset
+  assert entity._attributes == previous_attributes
+  warning_records = [record for record in caplog.records if record.levelno == logging.WARNING]
+  assert len(warning_records) == 1
+  assert str(missing_rate["start"]) in caplog.text
+  assert str(missing_rate["end"]) in caplog.text
+
+  rates_coordinator.data.rates.insert(1, missing_rate)
+  entity._handle_coordinator_update()
+
+  assert entity.native_value == previous_value
+  assert entity._missing_rate_error is None
+  assert entity.async_write_ha_state.call_count == 5
+
+  rates_coordinator.data.rates.pop(1)
+  with caplog.at_level(logging.WARNING):
+    entity._handle_coordinator_update()
+
+  warning_records = [record for record in caplog.records if record.levelno == logging.WARNING]
+  assert len(warning_records) == 2
+
+
+@pytest.mark.parametrize("entity_class, entity_module", [
+  (OctopusEnergyCurrentAccumulativeElectricityConsumption, current_accumulative_consumption),
+  (OctopusEnergyCurrentAccumulativeElectricityCost, current_accumulative_cost),
+])
+def test_when_calculation_raises_unexpected_error_then_error_is_not_suppressed(entity_class, entity_module, monkeypatch):
+  # Arrange
+  entity, _ = create_entity(entity_class)
+
+  def raise_unexpected_error(*args, **kwargs):
+    raise RuntimeError("unexpected error")
+
+  monkeypatch.setattr(entity_module, "calculate_electricity_consumption_and_cost", raise_unexpected_error)
+
+  # Act/Assert
+  with pytest.raises(RuntimeError, match="unexpected error"):
+    entity._handle_coordinator_update()


### PR DESCRIPTION
Fixes #1818.

## What changed

Current accumulative electricity sensors recalculate whenever consumption, rates or standing charge data changes. If a consumption interval could not be matched to a rate, that calculation raised a generic exception on every coordinator callback. With both the consumption and cost sensors active, this could produce a large number of repeated tracebacks while the rate data remained incomplete.

This adds a specific missing-rate error and handles it only in the two current accumulative electricity sensors. The calculation remains all-or-nothing, so the sensors never publish a partial consumption or cost total. While a rate is missing they report an unknown state, keep their last valid calculation in memory, and emit one warning per sensor for that failure episode without a traceback. They recover automatically once complete rate data is available.

Historical consumption, statistics refreshes and other callers remain strict and continue to surface missing rates as errors.

## Validation

- 700 unit tests passed on Python 3.13 with Home Assistant 2025.11.0
- 700 unit tests passed on Python 3.14 with Home Assistant 2025.11.0
- 700 unit tests passed on Python 3.14 with Home Assistant 2026.8.3
- Added regression coverage for first, middle and final missing intervals, repeated callbacks, state recovery and unexpected errors
- `npm run build` passed
