### PR TITLE
fix: Sum half hourly costs without rounding when building cost statistics

### DIFF
--- a/custom_components/octopus_energy/statistics/__init__.py
+++ b/custom_components/octopus_energy/statistics/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.components.recorder.statistics import (
 
 from ..const import DOMAIN
 from ..utils import get_active_tariff
-from ..utils.conversions import pence_to_pounds_pence, consumption_cost_in_pence
+from ..utils.conversions import consumption_cost_in_pence
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,8 +81,11 @@ def build_cost_statistics(current: datetime, consumptions, rates, consumption_ke
       raise Exception(f"Failed to find rate for consumption between {consumption_from} and {consumption_to}")
 
     if target_rate is None or target_rate == rate["value_inc_vat"]:
-      sums["total"] += pence_to_pounds_pence(consumption_cost_in_pence(consumption[consumption_key], rate["value_inc_vat"]))
-      states["total"] += pence_to_pounds_pence(consumption_cost_in_pence(consumption[consumption_key], rate["value_inc_vat"]))
+      # Rounding each half hourly cost to the nearest penny before summing skews
+      # the total, so the conversion to pounds is done without rounding
+      cost_pounds = consumption_cost_in_pence(consumption[consumption_key], rate["value_inc_vat"]) / 100
+      sums["total"] += cost_pounds
+      states["total"] += cost_pounds
 
     _LOGGER.debug(f'index: {index}; start: {start}; sums: {sums}; states: {states}; added: {(index) % 2 == 1}')
 

--- a/tests/unit/statistics/test_consumption_build_cost_statistics.py
+++ b/tests/unit/statistics/test_consumption_build_cost_statistics.py
@@ -1,9 +1,10 @@
 import pytest
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from unit import (create_consumption_data, create_rate_data)
 
 from custom_components.octopus_energy.statistics import build_cost_statistics
+from custom_components.octopus_energy.utils.conversions import consumption_cost_in_pence
 
 @pytest.mark.asyncio
 async def test_when_target_rate_specified_then_statistics_restructed():
@@ -98,3 +99,48 @@ async def test_when_target_rate_not_specified_then_statistics_not_restricted():
 
       assert "state" in item
       assert item["state"] == expected_state
+
+@pytest.mark.asyncio
+async def test_when_half_hourly_costs_are_fractions_of_pennies_then_sum_is_not_skewed_by_rounding():
+  # Arrange
+  period_from = datetime.strptime("2022-02-28T00:00:00Z", "%Y-%m-%dT%H:%M:%S%z")
+  period_to = datetime.strptime("2022-03-01T00:00:00Z", "%Y-%m-%dT%H:%M:%S%z")
+  current = datetime.strptime("2022-02-28T00:00:01Z", "%Y-%m-%dT%H:%M:%S%z")
+
+  # Realistic low overnight consumption where each half hour costs a fraction of a penny.
+  # Rounding each half hour to the nearest penny before summing skews the total
+  # (e.g. 48 slots of 0.028 kWh at 26.4159p/kWh sum to £0.48 instead of £0.38).
+  consumptions = []
+  current_valid_from = period_from
+  while current_valid_from < period_to:
+    current_valid_to = current_valid_from + timedelta(minutes=30)
+    consumptions.append({
+      "start": current_valid_from,
+      "end": current_valid_to,
+      "consumption": 0.028
+    })
+    current_valid_from = current_valid_to
+
+  rates = create_rate_data(period_from, period_to, [26.4159])
+  consumption_key = 'consumption'
+  latest_total_sum = 0
+
+  # Act
+  result = build_cost_statistics(
+    current,
+    consumptions,
+    rates,
+    consumption_key,
+    latest_total_sum
+  )
+
+  # Assert
+  assert result is not None
+
+  expected_total = sum(
+    consumption_cost_in_pence(consumptions[index]["consumption"], rates[index]["value_inc_vat"])
+    for index in range(len(consumptions))
+  ) / 100
+
+  assert result[-1]["sum"] == pytest.approx(expected_total)
+  assert result[-1]["state"] == pytest.approx(expected_total)


### PR DESCRIPTION
Fixes #1852

In `build_cost_statistics` each half hour cost was rounded to the nearest penny before being added to the running sum. With 48 slots per day and slot costs that are often below one penny, the error accumulates and the imported cost statistics deviate from the real cost by several percent. On my meter a day of 3.932 kWh on a flat 26.4159p/kWh tariff was imported as £1.10 instead of £1.04.

This change converts the pence value to pounds without rounding before summing. The billing rounding inside `consumption_cost_in_pence` (consumption and rate to 2 decimal places) stays as it is.

Also added a regression test with realistic small half hourly consumption values. It fails on the current `develop` and passes with this change. The existing tests did not catch the problem because they use 1 kWh per slot with whole-penny rates, so every slot cost is already exact and rounding changes nothing.

All unit tests pass (`python -m pytest tests/unit`, 694 passed).
