### PR TITLE
fix: use async_get_device_by_identifier with fallback to resolve Core 2027.8 deprecation

### DIFF
--- a/custom_components/octopus_energy/__init__.py
+++ b/custom_components/octopus_energy/__init__.py
@@ -176,7 +176,7 @@ async def async_setup_entry(hass, entry):
   hass.data[DOMAIN].setdefault(account_id, {})
 
   if config[CONFIG_KIND] == CONFIG_KIND_ACCOUNT:
-    await async_setup_dependencies(hass, config)
+    await async_setup_dependencies(hass, config, entry.entry_id)
     await hass.config_entries.async_forward_entry_setups(entry, ACCOUNT_PLATFORMS)
 
     async def async_close_connection(_) -> None:
@@ -267,7 +267,17 @@ async def async_setup_entry(hass, entry):
 
   return True
 
-async def async_setup_dependencies(hass, config):
+def _async_get_device_by_identifier(
+  device_registry: dr.DeviceRegistry,
+  identifier: tuple[str, str],
+  config_entry_id: str | None = None
+) -> dr.DeviceEntry | None:
+  """Retrieve a device by identifier with backward compatibility for older Home Assistant cores."""
+  if hasattr(device_registry, "async_get_device_by_identifier") and config_entry_id is not None:
+    return device_registry.async_get_device_by_identifier(identifier, config_entry_id)
+  return device_registry.async_get_device(identifiers={identifier})
+
+async def async_setup_dependencies(hass, config, entry_id: str | None = None):
   """Setup the coordinator and api client which will be shared by various entities"""
   account_id = config[CONFIG_ACCOUNT_ID]
 
@@ -348,13 +358,13 @@ async def async_setup_dependencies(hass, config):
 
         tariff = get_active_tariff(now, point["agreements"])
         if tariff is None:
-          gas_device = device_registry.async_get_device(identifiers={(DOMAIN, f"gas_{serial_number}_{mprn}")})
+          gas_device = _async_get_device_by_identifier(device_registry, (DOMAIN, f"gas_{serial_number}_{mprn}"), entry_id)
           if gas_device is not None:
             _LOGGER.debug(f'Removed gas device {serial_number}/{mprn} due to no active tariff')
             device_registry.async_remove_device(gas_device.id)
 
         # Remove gas meter devices which had incorrect identifier
-        gas_device = device_registry.async_get_device(identifiers={(DOMAIN, f"electricity_{serial_number}_{mprn}")})
+        gas_device = _async_get_device_by_identifier(device_registry, (DOMAIN, f"electricity_{serial_number}_{mprn}"), entry_id)
         if gas_device is not None:
           device_registry.async_remove_device(gas_device.id)
 
@@ -368,7 +378,7 @@ async def async_setup_dependencies(hass, config):
       
       if electricity_tariff is None:
         _LOGGER.debug(f'Removed electricity device {serial_number}/{mpan} due to no active tariff')
-        electricity_device = device_registry.async_get_device(identifiers={(DOMAIN, f"electricity_{serial_number}_{mpan}")})
+        electricity_device = _async_get_device_by_identifier(device_registry, (DOMAIN, f"electricity_{serial_number}_{mpan}"), entry_id)
         if electricity_device is not None:
           device_registry.async_remove_device(electricity_device.id)
 

--- a/tests/unit/test_device_registry_compat.py
+++ b/tests/unit/test_device_registry_compat.py
@@ -1,0 +1,58 @@
+import mock
+import pytest
+
+from custom_components.octopus_energy import _async_get_device_by_identifier
+
+
+def test_async_get_device_by_identifier_uses_modern_method():
+  registry = mock.MagicMock()
+  registry.async_get_device_by_identifier = mock.MagicMock(return_value="mock_device")
+  registry.async_get_device = mock.MagicMock()
+
+  result = _async_get_device_by_identifier(
+    registry,
+    ("octopus_energy", "electricity_12345_67890"),
+    "config_entry_abc",
+  )
+
+  assert result == "mock_device"
+  registry.async_get_device_by_identifier.assert_called_once_with(
+    ("octopus_energy", "electricity_12345_67890"),
+    "config_entry_abc",
+  )
+  registry.async_get_device.assert_not_called()
+
+
+def test_async_get_device_by_identifier_falls_back_when_missing_method():
+  # Legacy device registry without async_get_device_by_identifier attribute
+  registry = mock.MagicMock(spec=["async_get_device"])
+  registry.async_get_device.return_value = "legacy_device"
+
+  result = _async_get_device_by_identifier(
+    registry,
+    ("octopus_energy", "gas_12345_67890"),
+    "config_entry_abc",
+  )
+
+  assert result == "legacy_device"
+  registry.async_get_device.assert_called_once_with(
+    identifiers={("octopus_energy", "gas_12345_67890")}
+  )
+
+
+def test_async_get_device_by_identifier_falls_back_when_no_entry_id():
+  registry = mock.MagicMock()
+  registry.async_get_device_by_identifier = mock.MagicMock()
+  registry.async_get_device = mock.MagicMock(return_value="fallback_device")
+
+  result = _async_get_device_by_identifier(
+    registry,
+    ("octopus_energy", "gas_12345_67890"),
+    None,
+  )
+
+  assert result == "fallback_device"
+  registry.async_get_device.assert_called_once_with(
+    identifiers={("octopus_energy", "gas_12345_67890")}
+  )
+  registry.async_get_device_by_identifier.assert_not_called()


### PR DESCRIPTION
## What changed

In Home Assistant Core 2026.8+, device identifiers and connections are scoped per config entry rather than globally. As a result, `device_registry.async_get_device()` has been deprecated and is scheduled for removal in Home Assistant Core 2027.8.0.

Home Assistant logs the following warning during startup:
```text
Detected that custom integration 'octopus_energy' calls 'device_registry.async_get_device', which is deprecated because device identifiers and connections are no longer unique across config entries; use 'async_get_device_by_identifier', 'async_get_device_by_connection' or 'async_get_devices' instead at custom_components/octopus_energy/__init__.py, line 355: gas_device = device_registry.async_get_device(identifiers={(DOMAIN, f"electricity_{serial_number}_{mprn}")}). This will stop working in Home Assistant 2027.8.0
```

This PR:
1. Adds a backward-compatible helper `_async_get_device_by_identifier` in `custom_components/octopus_energy/__init__.py` that uses `device_registry.async_get_device_by_identifier(identifier, config_entry_id)` when available on modern Home Assistant versions, while gracefully falling back to `device_registry.async_get_device(identifiers={identifier})` on older versions (e.g. `2025.11.0` in the test suite).
2. Forwards `entry.entry_id` into `async_setup_dependencies(hass, config, entry.entry_id)`.
3. Migrates the three device lookup sites in `async_setup_dependencies` (gas device tariff cleanup, gas device legacy identifier cleanup, electricity device tariff cleanup) to `_async_get_device_by_identifier`.
4. Adds unit tests in `tests/unit/test_device_registry_compat.py` covering modern scoped lookups, legacy registry fallback, and missing `config_entry_id` fallback.

## Validation

- 698 unit tests passed on Python 3.14 (`pytest tests/unit`)
- Regression tests added covering modern and fallback device registry paths